### PR TITLE
Fix bug when running setup.py

### DIFF
--- a/pyoxidizer/src/pyrepackager/repackage.rs
+++ b/pyoxidizer/src/pyrepackager/repackage.rs
@@ -1129,9 +1129,9 @@ fn resolve_setup_py_install(
             &temp_dir_s,
             "--no-compile",
         ])
+        .stdout(std::process::Stdio::piped())
         .spawn()
         .expect("error running setup.py");
-
     {
         let stdout = cmd.stdout.as_mut().unwrap();
         let reader = BufReader::new(stdout);


### PR DESCRIPTION
In the current build cmd.stdout.as_mut().unwrap(); on line 1136 fails and the output of running setup.py goes to the command line. I believe this change fixes things.