### PR TITLE
Support extra_args for pip install simple

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -705,6 +705,10 @@ rule.
    Where to package resources associated with this rule.
    See :ref:`install_locations`.
 
+``extra_args`` (optional array of string)
+
+   An array of arguments added to the pip install command.
+
 This will include the ``pyflakes`` package and all its dependencies as embedded
 resources:
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -34,6 +34,9 @@ New Features
 * ``pip-install-simple`` packaging rule now supports ``excludes`` for excluding
   resources from packaging. (#21)
 
+* ``pip-install-simple`` packaging rule now supports ``extra_args`` for adding
+  parameters to the pip install command. (#42)
+
 All Relevant Changes
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pyoxidizer/src/pyrepackager/config.rs
+++ b/pyoxidizer/src/pyrepackager/config.rs
@@ -187,6 +187,7 @@ enum ConfigPythonPackaging {
         include_source: bool,
         #[serde(default = "EMBEDDED")]
         install_location: String,
+        extra_args: Option<Vec<String>>
     },
 
     #[serde(rename = "pip-requirements-file")]
@@ -344,6 +345,7 @@ pub struct PackagingPipInstallSimple {
     pub excludes: Vec<String>,
     pub include_source: bool,
     pub install_location: InstallLocation,
+    pub extra_args: Option<Vec<String>>
 }
 
 #[derive(Clone, Debug)]
@@ -655,6 +657,7 @@ pub fn parse_config(data: &[u8], config_path: &Path, target: &str) -> Result<Con
                 excludes,
                 include_source,
                 install_location,
+                extra_args
             } => {
                 if rule_target == "all" || rule_target == target {
                     Ok(Some(PythonPackaging::PipInstallSimple(
@@ -664,6 +667,7 @@ pub fn parse_config(data: &[u8], config_path: &Path, target: &str) -> Result<Con
                             excludes: excludes.clone(),
                             include_source: *include_source,
                             install_location: resolve_install_location(&install_location)?,
+                            extra_args: extra_args.clone()
                         },
                     )))
                 } else {

--- a/pyoxidizer/src/pyrepackager/repackage.rs
+++ b/pyoxidizer/src/pyrepackager/repackage.rs
@@ -930,18 +930,23 @@ fn resolve_pip_install_simple(
     let temp_dir_path = temp_dir.path();
     let temp_dir_s = temp_dir_path.display().to_string();
     info!(logger, "pip installing to {}", temp_dir_s);
+    let mut pip_args = vec![
+        "-m".to_string(),
+        "pip".to_string(),
+        "--disable-pip-version-check".to_string(),
+        "install".to_string(),
+        "--target".to_string(),
+        temp_dir_s,
+        rule.package.clone(),
+    ];
 
+    if rule.extra_args.is_some() {
+        pip_args.extend(rule.extra_args.clone().unwrap());
+    }
+    
     // TODO send stderr to stdout.
     let mut cmd = std::process::Command::new(&dist.python_exe)
-        .args(&[
-            "-m",
-            "pip",
-            "--disable-pip-version-check",
-            "install",
-            "--target",
-            &temp_dir_s,
-            &rule.package,
-        ])
+        .args(&pip_args)
         .stdout(std::process::Stdio::piped())
         .spawn()
         .expect("error running pip");


### PR DESCRIPTION
This pull request references #42

 -  added extra_args to pip install simple
 -  added documentation

I've looked at the TODO for piping stderr to stdout, it seems to be hard to do with the standard library, a crate named duct seems to be adapted to what we're looking for, I wasn't sure if you wanted another dependency or if there was a simpler way to do it so I kept it out of the pull request for now.