### PR TITLE
Fix grammar in first FAQ sentence

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -14,8 +14,8 @@ At https://github.com/indygreg/PyOxidizer/issues
 Why Build Another Python Application Packaging Tool?
 ====================================================
 
-It is true that several other *turn Python into distributable applications*
-tools exist! :ref:`comparisons` attempts to exhaustively compare ``PyOxidizer``
+It is true that several other tools exist to turn Python code into distributable applications!
+:ref:`comparisons` attempts to exhaustively compare ``PyOxidizer``
 to these myriad of tools. (If a tool is missing or the comparison incomplete
 or unfair, please file an issue so Python application maintainers can make
 better, informed decisions!)


### PR DESCRIPTION
Upon further reading, I guess if you really want to make the phrase "turn Python into distributable" into an adjective, the other alternative is to put dashes in there. But as is, it was so distracting and clear to me that this was a simple typo that I made a whole fork 8)