### PR TITLE
repair: pip-requirements-file type args must be requirements_path not…

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -761,7 +761,7 @@ Example:
 
    [[packaging_rule]]
    type = "pip-requirements-file"
-   path = "/home/gps/src/myapp/requirements.txt"
+   requirements_path = "/home/gps/src/myapp/requirements.txt"
 
 ``setup-py-install``
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
… path

   [[packaging_rule]]
   type = "pip-requirements-file"
   path = "/home/gps/src/myapp/requirements.txt"

to

   [[packaging_rule]]
   type = "pip-requirements-file"
   requirements_path = "/home/gps/src/myapp/requirements.txt"

