### PR TITLE
docs: Be explicit up front about getting the actual executable.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -104,20 +104,24 @@ But if you aren't, keep reading.
 
 The default project created by ``pyoxidizer init`` will produce an
 executable that embeds Python and starts a Python REPL by default. Let's
-test that::
+build that executable, with ``pyoxidizer build``::
 
    $ cd pyapp
-   $ pyoxidizer run
+   $ pyoxidizer build
    no existing PyOxidizer artifacts found
    processing config file /home/gps/src/pyapp/pyoxidizer.toml
    resolving Python distribution...
    ...
    pyapp packaged into /home/gps/src/pyapp/build/apps/pyapp/debug
+   executable path: /home/gps/src/pyapp/build/apps/pyapp/debug/pyapp
+
+Now just run the executable!  The path is given at the end of the
+``pyoxidizer build`` output::
+
+   $ /home/gps/src/pyapp/build/apps/pyapp/debug/pyapp
    >>>
 
-If all goes according to plan, you just started a Rust executable which
-started a Python interpreter, which started an interactive Python debugger!
-Try typing in some Python code::
+Try some Python code into this REPL::
 
    >>> print("hello, world")
    hello, world

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -112,9 +112,7 @@ test that::
    processing config file /home/gps/src/pyapp/pyoxidizer.toml
    resolving Python distribution...
    ...
-      Compiling pyapp v0.1.0 (/home/gps/src/pyapp)
-       Finished dev [unoptimized + debuginfo] target(s) in 53.14s
-        Running `target/debug/testapp`
+   pyapp packaged into /home/gps/src/pyapp/build/apps/pyapp/debug
    >>>
 
 If all goes according to plan, you just started a Rust executable which


### PR DESCRIPTION
Looking at the getting-started page of the docs, because everything
is in terms of `pyoxidizer run` it's not obvious how to actually
lay hands on the single executable file that PyOxidizer produces.
Here's one example of a puzzled would-be user:
  https://groups.google.com/forum/#!topic/pyoxidizer-users/rUyM3iTpZq0

Fix that by breaking up the first example into `pyoxidizer build`
and then an explicit invocation of the built executable.

(Also a smaller preparatory commit.)
