### PR TITLE
Fix loading of resources using incorrect offset

### DIFF
--- a/pyoxidizer/src/pyembed/importer.rs
+++ b/pyoxidizer/src/pyembed/importer.rs
@@ -216,7 +216,7 @@ impl PythonResourcesData {
         }
 
         let mut name_offset = reader.position() as usize;
-        let data_offset = name_offset + total_names_length;
+        let mut data_offset = name_offset + total_names_length;
         let mut res = HashMap::new();
 
         for (package_name_length, package_index) in index {
@@ -238,6 +238,8 @@ impl PythonResourcesData {
                 name_offset += resource_name_length;
 
                 let resource_data = &data[data_offset..data_offset + resource_data_length];
+
+                data_offset += resource_data_length;
 
                 package_data.insert(resource_name, resource_data);
             }


### PR DESCRIPTION
Hi! Thanks for this awesome project.

When using `__loader__.get_resource_loader(package).open_resource(filename)`, we were getting a strange result: the contents of the file came out together with the content of other embedded files.

Turns out it was always reading from the start of the first file, since the data offset wasn't getting updated as it moved along the files.

This is my first contribution to a Rust project, so feel free to tell me if I made some mistake, though the change is simple enough that I hope I haven't 😄 