### PR TITLE
Add stdlib excludes

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -640,6 +640,16 @@ The following arguments control behavior:
 
    Default is ``0``, which is the Python default.
 
+``excludes`` (array of string)
+   An array of module names to exclude.
+
+   A value in this array will match on an exact full resource name match or
+   on a package prefix match. e.g. ``foo`` will match the module ``foo``, the
+   package ``foo``, and any sub-modules in ``foo``. e.g. it will match
+   ``foo.bar`` but will not match ``foofoo``.
+
+   Default is an empty array.
+
 ``include_source`` (bool)
    Whether to include the source code for modules in addition to bytecode.
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -21,7 +21,9 @@ Version History
 next
 ----
 
-Not yet released.
+* The ``stdlib`` packaging rule now supports ``excludes`` option
+  that allows ignoring specific modules, especially useful for removing
+  unnecessary default Python packages such as distutils, pip and ensurepip.
 
 Backwards Compatibility Notes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pyoxidizer/src/pyrepackager/config.rs
+++ b/pyoxidizer/src/pyrepackager/config.rs
@@ -67,6 +67,7 @@ pub struct PackagingStdlibExtensionVariant {
 pub struct PackagingStdlib {
     pub optimize_level: i64,
     pub exclude_test_modules: bool,
+    pub excludes: Vec<String>,
     pub include_source: bool,
     pub include_resources: bool,
     pub install_location: InstallLocation,

--- a/pyoxidizer/src/pyrepackager/packaging_rule.rs
+++ b/pyoxidizer/src/pyrepackager/packaging_rule.rs
@@ -511,6 +511,20 @@ fn resolve_stdlib(
             continue;
         }
 
+        let mut relevant = true;
+
+        for exclude in &rule.excludes {
+            let prefix = exclude.clone() + ".";
+
+            if name == exclude || name.starts_with(&prefix) {
+                relevant = false;
+            }
+        }
+
+        if !relevant {
+            continue;
+        }
+
         let is_package = is_package_from_path(&fs_path);
         let source = fs::read(fs_path).expect("error reading source file");
 

--- a/pyoxidizer/src/starlark/python_packaging.rs
+++ b/pyoxidizer/src/starlark/python_packaging.rs
@@ -704,16 +704,23 @@ starlark_module! { python_packaging_env =>
     Stdlib(
         optimize_level=0,
         exclude_test_modules=true,
+        excludes=None,
         include_source=true,
         include_resources=true,
         install_location="embedded"
     ) {
         required_type_arg("optimize_level", "int", &optimize_level)?;
+        optional_list_arg("excludes", "string", &excludes)?;
         let exclude_test_modules = required_bool_arg("exclude_test_modules", &exclude_test_modules)?;
         let include_source = required_bool_arg("include_source", &include_source)?;
         let include_resources = required_bool_arg("include_resources", &include_resources)?;
         let install_location = required_str_arg("install_location", &install_location)?;
 
+        let excludes = match excludes.get_type() {
+            "list" => excludes.into_iter()?.map(|x| x.to_string()).collect(),
+            "NoneType" => Vec::new(),
+            _ => panic!("should have validated type above"),
+        };
         let install_location = resolve_install_location(&install_location).or_else(|e| {
             Err(RuntimeError {
                 code: INCORRECT_PARAMETER_TYPE_ERROR_CODE,
@@ -725,6 +732,7 @@ starlark_module! { python_packaging_env =>
         let rule = PackagingStdlib {
             optimize_level: optimize_level.to_int()?,
             exclude_test_modules,
+            excludes,
             include_source,
             include_resources,
             install_location,
@@ -967,6 +975,7 @@ mod tests {
         let wanted = PackagingStdlib {
             optimize_level: 0,
             exclude_test_modules: true,
+            excludes: Vec::new(),
             include_source: true,
             include_resources: true,
             install_location: InstallLocation::Embedded,


### PR DESCRIPTION
Allows exclusion of stdlib modules such as distutils, pip, ensurepip
which are large and often unnecessary in a standalone binary.