### PR TITLE
distutils: Use ext_package in built ext names

### DIFF
--- a/pyoxidizer/src/distutils/_msvccompiler.py
+++ b/pyoxidizer/src/distutils/_msvccompiler.py
@@ -558,7 +558,9 @@ class MSVCCompiler(CCompiler) :
                            extra_postargs=None,
                            build_temp=None,
                            target_lang=None,
-                           name=None):
+                           name=None,
+                           package=None,
+                           ):
 
         if 'PYOXIDIZER_DISTUTILS_STATE_DIR' not in os.environ:
             raise Exception('PYOXIDIZER_DISTUTILS_STATE_DIR not defined')
@@ -593,7 +595,7 @@ class MSVCCompiler(CCompiler) :
         json_path = os.path.join(dest_path, 'extension.%s.json' % name)
         with open(json_path, 'w', encoding='utf-8') as fh:
             data = {
-                'name': name,
+                'name': '%s.%s' % (package, name) if package else name,
                 'objects': object_paths,
                 'output_filename': os.path.abspath(output_filename),
                 'libraries': libraries or [],

--- a/pyoxidizer/src/distutils/command/build_ext.py
+++ b/pyoxidizer/src/distutils/command/build_ext.py
@@ -553,7 +553,7 @@ class build_ext(Command):
 
         if hasattr(self.compiler, 'extension_link_shared_object'):
             fn = self.compiler.extension_link_shared_object
-            extra_kwargs = {'name': ext.name}
+            extra_kwargs = {'name': ext.name, 'package': self.package}
         else:
             fn = self.compiler.link_shared_object
             extra_kwargs = {}

--- a/pyoxidizer/src/distutils/unixccompiler.py
+++ b/pyoxidizer/src/distutils/unixccompiler.py
@@ -220,7 +220,9 @@ class UnixCCompiler(CCompiler):
                            extra_postargs=None,
                            build_temp=None,
                            target_lang=None,
-                           name=None):
+                           name=None,
+                           package=None,
+                           ):
 
         if 'PYOXIDIZER_DISTUTILS_STATE_DIR' not in os.environ:
             raise Exception('PYOXIDIZER_DISTUTILS_STATE_DIR not defined')
@@ -249,7 +251,7 @@ class UnixCCompiler(CCompiler):
         json_path = os.path.join(dest_path, 'extension.%s.json' % name)
         with open(json_path, 'w', encoding='utf-8') as fh:
             data = {
-                'name': name,
+                'name': '%s.%s' % (package, name) if package else name,
                 'objects': object_paths,
                 'output_filename': os.path.abspath(output_filename),
                 'libraries': libraries or [],


### PR DESCRIPTION
distutils setup() accepts an ext_package value for the name
of the package for a group of built extensions.

Fixes https://github.com/indygreg/PyOxidizer/issues/26