### PR TITLE
Add extra_env to pip packaging rules

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -723,6 +723,13 @@ rule.
    Name of the package to install. This is added as a positional argument to
    ``pip install``.
 
+``extra_env`` (dict)
+   Extra environment variables to pass to the ``pip install`` invocation.
+
+   ``pip install`` and some ``setup.py`` scripts accept environment variables
+   to customize execution behavior. This option can be defined to pass those
+   along to the invocation.
+
 ``optimize_level`` (int)
    The module optimization level for packaged bytecode.
 
@@ -773,6 +780,13 @@ operation.
 
 ``requirements_path`` (string)
    Filesystem path to pip requirements file.
+
+``extra_env`` (dict)
+   Extra environment variables to pass to the ``pip install`` invocation.
+
+   ``pip install`` and some ``setup.py`` scripts accept environment variables
+   to customize execution behavior. This option can be defined to pass those
+   along to the invocation.
 
 ``optimize_level`` (int)
    The module optimization level for packaged bytecode.

--- a/pyoxidizer/src/pyrepackager/config.rs
+++ b/pyoxidizer/src/pyrepackager/config.rs
@@ -94,6 +94,7 @@ pub struct PackagingPackageRoot {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PackagingPipInstallSimple {
     pub package: String,
+    pub extra_env: HashMap<String, String>,
     pub optimize_level: i64,
     pub excludes: Vec<String>,
     pub include_source: bool,
@@ -105,6 +106,7 @@ pub struct PackagingPipInstallSimple {
 pub struct PackagingPipRequirementsFile {
     // TODO resolve to a PathBuf.
     pub requirements_path: String,
+    pub extra_env: HashMap<String, String>,
     pub optimize_level: i64,
     pub include_source: bool,
     pub install_location: InstallLocation,

--- a/pyoxidizer/src/pyrepackager/packaging_rule.rs
+++ b/pyoxidizer/src/pyrepackager/packaging_rule.rs
@@ -743,7 +743,7 @@ fn resolve_pip_install_simple(
     let temp_dir =
         tempdir::TempDir::new("pyoxidizer-pip-install").expect("could not creat temp directory");
 
-    let extra_envs = prepare_hacked_distutils(logger, dist, temp_dir.path(), &[])
+    let mut extra_envs = prepare_hacked_distutils(logger, dist, temp_dir.path(), &[])
         .expect("unable to hack distutils");
 
     let target_dir_path = temp_dir.path().join("install");
@@ -771,6 +771,10 @@ fn resolve_pip_install_simple(
 
     if rule.extra_args.is_some() {
         pip_args.extend(rule.extra_args.clone().unwrap());
+    }
+
+    for (key, value) in rule.extra_env.iter() {
+        extra_envs.insert(key.clone(), value.clone());
     }
 
     // TODO send stderr to stdout.
@@ -884,7 +888,7 @@ fn resolve_pip_requirements_file(
     let temp_dir =
         tempdir::TempDir::new("pyoxidizer-pip-install").expect("could not create temp directory");
 
-    let extra_envs = prepare_hacked_distutils(logger, dist, temp_dir.path(), &[])
+    let mut extra_envs = prepare_hacked_distutils(logger, dist, temp_dir.path(), &[])
         .expect("unable to hack distutils");
 
     let target_dir_path = temp_dir.path().join("install");
@@ -906,6 +910,10 @@ fn resolve_pip_requirements_file(
         "--requirement",
         &rule.requirements_path,
     ]);
+
+    for (key, value) in rule.extra_env.iter() {
+        extra_envs.insert(key.clone(), value.clone());
+    }
 
     // TODO send stderr to stdout.
     let mut cmd = std::process::Command::new(&dist.python_exe)


### PR DESCRIPTION
The `extra_env` argument for the setup.py rule is also
applicable for the two pip rules.