### PR TITLE
Support extra_args in PipRequirementsFile

### DIFF
--- a/pyoxidizer/src/pyrepackager/config.rs
+++ b/pyoxidizer/src/pyrepackager/config.rs
@@ -108,6 +108,7 @@ pub struct PackagingPipRequirementsFile {
     pub optimize_level: i64,
     pub include_source: bool,
     pub install_location: InstallLocation,
+    pub extra_args: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/pyoxidizer/src/pyrepackager/packaging_rule.rs
+++ b/pyoxidizer/src/pyrepackager/packaging_rule.rs
@@ -891,21 +891,29 @@ fn resolve_pip_requirements_file(
     let target_dir_s = target_dir_path.display().to_string();
     warn!(logger, "pip installing to {}", target_dir_s);
 
-    let mut args = vec!["-m", "pip", "--disable-pip-version-check"];
+    let mut args: Vec<String> = vec![
+        "-m".to_string(),
+        "pip".to_string(),
+        "--disable-pip-version-check".to_string(),
+    ];
 
     if verbose {
-        args.push("--verbose");
+        args.push("--verbose".to_string());
     }
 
-    args.extend(&[
-        "install",
-        "--target",
-        &target_dir_s,
-        "--no-binary",
-        ":all:",
-        "--requirement",
-        &rule.requirements_path,
+    args.extend(vec![
+        "install".to_string(),
+        "--target".to_string(),
+        target_dir_s,
+        "--no-binary".to_string(),
+        ":all:".to_string(),
+        "--requirement".to_string(),
+        rule.requirements_path.to_string(),
     ]);
+
+    if rule.extra_args.is_some() {
+        args.extend(rule.extra_args.clone().unwrap());
+    };
 
     // TODO send stderr to stdout.
     let mut cmd = std::process::Command::new(&dist.python_exe)


### PR DESCRIPTION
I needed to pass `--index-url`, `--extra-index-url`, and `--trusted-host` to `PipRequirementsFile` rule, but this wasn't supported.  Here's a patch to plumb that through.  I'm a Rust newbie so my code might suck, but it WFM :).  Happy for any feedback!