### PR TITLE
pyembed: Add private finder._package_list

### DIFF
--- a/pyoxidizer/src/pyembed/importer.rs
+++ b/pyoxidizer/src/pyembed/importer.rs
@@ -453,6 +453,23 @@ py_class!(class PyOxidizerFinder |py| {
             Ok(py.None())
         }
     }
+
+    // Support for obtaining the internal package list, usable to build Python logic
+    // to inspect the binary or expose the package list in a format usable by Python
+    // libraries.
+    // As an internal support method, this API is not supported and may be removed.
+    def _package_list(&self) -> PyResult<PyObject> {
+        let known_modules = self.known_modules(py);
+        let mut names = Vec::with_capacity(known_modules.len());
+
+        for name in known_modules.keys() {
+            names.push(name.to_py_object(py));
+        }
+
+        let names_list = names.to_py_object(py);
+
+        Ok(names_list.as_object().clone_ref(py))
+    }
 });
 
 #[allow(unused_doc_comments)]


### PR DESCRIPTION
In order to programatically inspect and validate the contents
of the executable from Python code, the internal package list
needs to be exposed.

This also provides the ability for Python code to implement
package listing support in the various frameworks such as
pkg_resources and importlib.metadata's find_distributions.

Related to https://github.com/indygreg/PyOxidizer/issues/140
Related to https://github.com/indygreg/PyOxidizer/issues/141