### PR TITLE
Add recommendation to use pip-licenses

### DIFF
--- a/docs/packaging_licensing.rst
+++ b/docs/packaging_licensing.rst
@@ -53,6 +53,9 @@ strong copyleft protections in the GPL license.
 
    It is critical to audit which Python extensions and packages are being
    packaged because of licensing requirements of various extensions.
+   Consider using a package such as 
+   `pip-licenses <https://github.com/raimon49/pip-licenses>`_ to
+   generate a license report for your Python packages.
 
 Showing Python Distribution Licenses
 ------------------------------------


### PR DESCRIPTION
[`pip-licenses`](https://github.com/raimon49/pip-licenses) can help audit Python package licenses, by generating a license report for a set of dependencies.