### PR TITLE
Re-run the pyembed build script if the config file contents have changed

### DIFF
--- a/pyoxidizer/src/project_building.rs
+++ b/pyoxidizer/src/project_building.rs
@@ -391,6 +391,8 @@ pub fn run_from_build(
         panic!("PyOxidizer config file does not exist");
     }
 
+    println!("cargo:rerun-if-changed={}", config_path.display());
+
     let dest_dir = match env::var("PYOXIDIZER_ARTIFACT_DIR") {
         Ok(ref v) => PathBuf::from(v),
         Err(_) => PathBuf::from(env::var("OUT_DIR").context("OUT_DIR")?),


### PR DESCRIPTION
When editing the `pyoxidizer.bzl` config file, `pyembed`'s `build.rs` will not re-run in `build-mode-pyoxidizer-exe` mode.

Further changes in this area are likely necessary though: when the config file is executed, it can walk various portions of the real filesystem to discover what it needs to re-run for (via e.g. `read_package_root` and others).