### PR TITLE
Render the extension name when we fail to embed something.

### DIFF
--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -1668,7 +1668,7 @@ impl PythonBinaryBuilder for StandalonePythonExecutableBuilder {
                                 .resolve()?,
                         )
                 } else {
-                    Err(anyhow!("in-memory-only resources policy active but in-memory extension module importing not supported by this configuration"))
+                    Err(anyhow!("in-memory-only resources policy active but in-memory extension module importing not supported by this configuration: cannot load {}", extension_module.name))
                 }
             }
             PythonResourcesPolicy::FilesystemRelativeOnly(ref prefix) => {


### PR DESCRIPTION
When a `PythonExtensionModule` is discovered via a batch-discovery method like `read_package_root` or `pip_install`, "which" module is causing the trouble is not obvious. Rendering the extension module name gives information about the culprit (although it will not pinpoint a file on disk or `requirements.txt` entry precisely).