### PR TITLE
Passing dist to make_exe in eample

### DIFF
--- a/docs/packaging_python_files.rst
+++ b/docs/packaging_python_files.rst
@@ -131,7 +131,7 @@ comments removed for brevity):
 
 .. code-block:: python
 
-   def make_exe():
+   def make_exe(dist):
        dist = default_python_distribution()
 
        policy = dist.make_python_packaging_policy()

--- a/docs/packaging_python_files.rst
+++ b/docs/packaging_python_files.rst
@@ -183,7 +183,7 @@ following:
 
 .. code-block:: python
 
-   def make_exe():
+   def make_exe(dist):
        dist = default_python_distribution()
 
        policy = dist.make_python_packaging_policy()


### PR DESCRIPTION
Seems like dist needs to be passed to `make_exe()`, which is a bit weird, because in the line below `dist` gets overwritten. But if `dist` is not passed, you get the error from #306. 

Fixes #306