### PR TITLE
Fix #321: Backslashes in module_search_paths

### DIFF
--- a/pyoxidizer/src/py_packaging/config.rs
+++ b/pyoxidizer/src/py_packaging/config.rs
@@ -379,18 +379,15 @@ mod tests {
             haystack.contains(needle),
             "\n\x1b[31m\x1b[1mexpected to find\x1b[0m\n{}\n\x1b[31m\x1b[1min\x1b[0m\n{}",
             needle,
-            haystack);
+            haystack
+        );
 
         Ok(())
     }
 
-    fn assert_serialize_module_search_paths(
-        paths: &[&str],
-        expected_contents: &str,
-    ) -> Result<()> {
+    fn assert_serialize_module_search_paths(paths: &[&str], expected_contents: &str) -> Result<()> {
         let mut config = EmbeddedPythonConfig::default();
-        config.config.module_search_paths =
-            Some(paths.iter().map(PathBuf::from).collect());
+        config.config.module_search_paths = Some(paths.iter().map(PathBuf::from).collect());
 
         let code = config.to_oxidized_python_interpreter_config_rs(None)?;
         assert_contains(&code, expected_contents)
@@ -435,7 +432,8 @@ mod tests {
 
         assert_contains(
             &code,
-            "tcl_library: Some(std::path::PathBuf::from(\"c:\\\\windows\")),")
+            "tcl_library: Some(std::path::PathBuf::from(\"c:\\\\windows\")),",
+        )
     }
 
     // TODO enable once CI has a linkable Python.


### PR DESCRIPTION
161f76869b9308cc8626e8d25d857ab16c2fae84 and 93af6273d6902aa04a05de3b6a1e5fd15d42f3b1 added support for Windows paths containing backslashes for all `PythonInterpreterConfig` fields except `module_search_paths`. This patch extends the support to `module_search_paths` by refactoring the serialization of `std::path::PathBuf`. Now all `PythonInterpreterConfig` fields containing paths are serialized using the same code path. I added a test for backslashes in `module_search_paths`.

I also refactored the test code for path serialization to show the expected and incorrectly computed results upon test failure. I hope this makes the tests easier to read. Anyway, it helped me debug this patch.