### PR TITLE
Fix #337: Add __path__ filtering to OxidizedFinder's pkgutil.iter_modules support

### DIFF
--- a/docs/config_type_python_interpreter_config.rst
+++ b/docs/config_type_python_interpreter_config.rst
@@ -220,6 +220,10 @@ Whether to install the ``oxidized_importer`` meta path importer
 (:ref:`oxidized_importer`) on ``sys.meta_path`` during interpreter
 initialization.
 
+If :ref:`config_type_python_interpreter_config_filesystem_importer` is also
+``True``, the importer's :ref:`path_hook <oxidized_finder_path_hook>` method is
+appended to ``sys.path_hooks`` at the end of interpreter initialization.
+
 Defaults to ``True``.
 
 .. _config_type_python_interpreter_config_filesystem_importer:
@@ -231,6 +235,12 @@ Defaults to ``True``.
 
 Whether to install the standard library path-based importer for
 loading Python modules from the filesystem.
+
+If :ref:`config_type_python_interpreter_config_oxidized_importer` is also
+``True``, the :ref:`path_hook <oxidized_finder_path_hook>` method of the
+``oxidized_importer`` meta path importer (:ref:`oxidized_importer`) on
+``sys.meta_path`` is appended to ``sys.path_hooks`` at the end of interpreter
+initialization.
 
 If not enabled, Python modules will not be loaded from the filesystem
 (via ``sys.path`` discovery): only modules indexed by ``oxidized_importer``

--- a/pyembed/Cargo.toml
+++ b/pyembed/Cargo.toml
@@ -16,6 +16,8 @@ links = "pythonXY"
 [dependencies]
 # Update documentation in lib.rs when new dependencies are added.
 anyhow = "1.0"
+# When https://github.com/dgrunwald/rust-cpython/issues/246 gets fixed, remove
+# `@unittest.expectedFailure` in `test_importer_path_entry_finder.py`.
 cpython = "0.5.2"
 dunce = "1.0"
 jemalloc-sys = { version = "0.3", optional = true }

--- a/pyembed/docs/oxidized_importer_behavior_and_compliance.rst
+++ b/pyembed/docs/oxidized_importer_behavior_and_compliance.rst
@@ -57,6 +57,8 @@ these missing attributes is to avoid in-memory loading.
    files*. See :ref:`resource_files` for more on this topic, including
    how to port code to more modern Python APIs for loading resources.
 
+.. _oxidized_finder_behavior_and_compliance_path:
+
 ``__path__`` Module Attribute
 =============================
 
@@ -187,8 +189,9 @@ differences in behavior:
   ``OxidizedFinder.iter_modules()`` returns a ``list``. ``list`` is
   iterable and this difference should hopefully be a harmless
   implementation detail.
-* ``pkgutil.iter_modules()`` inspects ``sys.path_importer_cache`` as
-  part of evaluating its ``path`` argument. However, ``OxidizedFinder``
-  does not populate ``sys.path_importer_cache``, so path-based
-  filtering via ``pkgutil.iter_modules(path=...)`` will not work like it
-  does with the standard library's importer.
+* Support for the ``path`` argument to ``pkgutil.iter_modules()`` requires that
+  both :ref:`config_type_python_interpreter_config_oxidized_importer` and
+  :ref:`config_type_python_interpreter_config_filesystem_importer` of
+  :ref:`config_type_python_interpreter_config` be set to ``True`` so that
+  ``OxidizedFinder``'s :ref:`path_hook <oxidized_finder_path_hook>` is installed
+  in ``sys.path_hooks``.

--- a/pyembed/docs/oxidized_importer_oxidized_finder.rst
+++ b/pyembed/docs/oxidized_importer_oxidized_finder.rst
@@ -272,7 +272,7 @@ When ``path_hook``, bound to an ``OxidizedFinder`` instance ``self``, is in
 ``sys.path_hooks``, ``pkgutil.iter_modules`` can search ``self``'s embedded
 resources, filtering by its ``path`` argument. Additionally, if you add
 ``sys.executable`` to ``sys.path``, the meta-path finder
-``importlib.machineray.PathFinder`` can find ``self``'s embedded resources.
+``importlib.machinery.PathFinder`` can find ``self``'s embedded resources.
 
 ``path_hook`` returns a `path-entry finder`_\ [#fn-path-entry-finder]_ that can
 find modules at the top level or inside a package according to ``path``.

--- a/pyembed/src/config.rs
+++ b/pyembed/src/config.rs
@@ -158,10 +158,23 @@ pub struct OxidizedPythonInterpreterConfig<'a> {
     /// build-time configuration.
     pub set_missing_path_configuration: bool,
 
-    /// Whether to install our custom meta path importer on interpreter init.
+    /// Whether to install our custom meta path importer on interpreter init,
+    /// and, if [`filesystem_importer`] is `true`, to add its ``path_hook``
+    /// method to [`sys.path_hooks`] for `PathFinder`'s and [`pkgutil`]'s use.
+    ///
+    /// [`filesystem_importer`]: #structfield.filesystem_importer
+    /// [`sys.path_hooks`]: https://docs.python.org/3/library/sys.html#sys.path_hooks
+    /// [`pkgutil`]: https://docs.python.org/3/library/pkgutil.html
     pub oxidized_importer: bool,
 
-    /// Whether to install the default `PathFinder` meta path finder.
+    /// Whether to install the default `PathFinder` meta path finder and, if
+    /// [`oxidized_importer`] is `true`, to add our custom meta path
+    /// importer's ``path_hook`` method to [`sys.path_hooks`] for `PathFinder`'s
+    /// and [`pkgutil`]'s use.
+    ///
+    /// [`oxidized_importer`]: #structfield.oxidized_importer
+    /// [`sys.path_hooks`]: https://docs.python.org/3/library/sys.html#sys.path_hooks
+    /// [`pkgutil`]: https://docs.python.org/3/library/pkgutil.html
     pub filesystem_importer: bool,
 
     /// References to packed resources data.

--- a/pyembed/src/importer.rs
+++ b/pyembed/src/importer.rs
@@ -909,7 +909,9 @@ impl OxidizedFinder {
             None
         };
 
-        resources_state.pkgutil_modules_infos(py, prefix, state.optimize_level, |_resource| true)
+        resources_state.pkgutil_modules_infos(py, prefix, state.optimize_level, |resource| {
+            _PathEntryFinder::is_visible("", &resource.name)
+        })
     }
 
     // Canonicalize the path to the current executable or raise an OSError.
@@ -1025,7 +1027,7 @@ py_class!(class _PathEntryFinder |py| {
         self.finder(py).call_method(py, "invalidate_caches", NoArgs, None)
     }
 
-    def iter_modules(&self, prefix: Option<&str> = None) -> PyResult<PyList> {
+    def iter_modules(&self, prefix: &str = "") -> PyResult<PyList> {
         self.iter_modules_impl(py, prefix)
     }
 
@@ -1073,11 +1075,11 @@ impl _PathEntryFinder {
             .map(|spec| if spec == py.None() { None } else { Some(spec) })
     }
 
-    fn iter_modules_impl(&self, py: Python, prefix: Option<&str>) -> PyResult<PyList> {
+    fn iter_modules_impl(&self, py: Python, prefix: &str) -> PyResult<PyList> {
         let state = self.finder(py).cast_as::<OxidizedFinder>(py)?.state(py);
         let modules = state.get_resources_state().pkgutil_modules_infos(
             py,
-            prefix.map(|p| p.to_string()),
+            Some(prefix.to_string()),
             state.optimize_level,
             |resource| _PathEntryFinder::is_visible(self.package(py), &resource.name),
         );

--- a/pyembed/src/importer.rs
+++ b/pyembed/src/importer.rs
@@ -533,6 +533,10 @@ py_class!(class OxidizedFinder |py| {
         oxidized_finder_new(py, relative_path_origin)
     }
 
+    def path_hook(&self, path: PyObject) -> PyResult<_PathEntryFinder> {
+        self.path_hook_impl(py, path)
+    }
+
     def index_bytes(&self, data: PyObject) -> PyResult<PyObject> {
         self.index_bytes_impl(py, data)
     }
@@ -905,7 +909,212 @@ impl OxidizedFinder {
             None
         };
 
-        resources_state.pkgutil_modules_infos(py, prefix, state.optimize_level)
+        resources_state.pkgutil_modules_infos(py, prefix, state.optimize_level, |_resource| true)
+    }
+
+    fn path_hook_impl(&self, py: Python, path: PyObject) -> PyResult<_PathEntryFinder> {
+        // Compute _PathEntryFinder::package
+        let pkg = {
+            // Get the canonicalized path to the current executable or raise an OSError.
+            let current_exe = {
+                let current_exe = &self.state(py).get_resources_state().current_exe;
+                current_exe.canonicalize().map_err(|err| {
+                    let exe = current_exe.display();
+                    // Use a Python expression instead of PyErr::new to ensure we get the
+                    // right OSError subclass.
+                    let strerror = format!("cannot open current executable: '{}'", exe);
+                    let raw_os_error = err
+                        .raw_os_error()
+                        .map_or_else(|| "None".to_string(), |err_code| err_code.to_string());
+                    let code = if cfg!(windows) {
+                        format!(
+                            "OSError(None, r\"{}\", r\"{}\", {})",
+                            strerror, exe, raw_os_error
+                        )
+                    } else {
+                        format!("OSError({}, r\"{}\", r\"{}\")", raw_os_error, strerror, exe)
+                    };
+                    py.eval(&code, None, None).map_or_else(
+                        |err_creating_exc| err_creating_exc,
+                        |exc| PyErr::from_instance(py, exc),
+                    )
+                })
+            }?;
+            let not_exe_err = || {
+                let msg = format!(
+                    "path {} does not begin in \'{}\' (if you're sure it does, check Python's file-system encoding)", &path, current_exe.display());
+                let mut err = PyErr::new::<ImportError, _>(py, msg);
+                let exc = err.instance(py);
+                if let Err(setattr_err) = exc.setattr(py, "path", path.clone_ref(py)) {
+                    setattr_err
+                } else {
+                    err
+                }
+            };
+            let pbuf = pyobject_to_pathbuf(py, path.clone_ref(py))?;
+            let mut p: &std::path::Path = pbuf.as_ref();
+            // path could point "inside" current_exe. If we can't canonicalize,
+            // strip the last component and check again. (zipimporter does
+            // somethings similar)
+            let mut abs_p = p.canonicalize();
+            // Count the number of components at the end of `path` will be in pkg
+            let mut parts: usize = 0;
+            while abs_p.is_err() {
+                p = match p.parent() {
+                    Some(parent) => {
+                        parts += 1;
+                        parent
+                    }
+                    None => {
+                        return Err(not_exe_err());
+                    }
+                };
+                abs_p = p.canonicalize();
+            }
+            let abs_p = abs_p.unwrap();
+            if abs_p != current_exe {
+                return Err(not_exe_err());
+            }
+            // Extract the part of `path` after current_exe
+            // FIXME: This takes two allocations, but it shouldn't even use one.
+            let tail = pbuf
+                .iter()
+                .rev()
+                .take(parts)
+                .collect::<std::path::PathBuf>()
+                .iter()
+                .rev()
+                .collect::<std::path::PathBuf>();
+            _PathEntryFinder::parse_path_to_pkg(py, &tail)?
+        };
+        let finder = OxidizedFinder::create_instance(py, Arc::clone(self.state(py)))?;
+        // sys.path_hooks is only read after importlib._bootstrap_internal has
+        // been setup, either in that module or after initialization by
+        // PyImport_GetImporter checking for the existence of config->run_filename
+        // has been setup, so it's safe to import os now.
+        let paths = PyList::new(py, &[py.import("os")?.call(py, "fspath", (path,), None)?]);
+        _PathEntryFinder::create_instance(py, finder.into_object(), paths, pkg)
+    }
+}
+
+// A (mostly compliant) `importlib.abc.PathEntryFinder` that delegates paths
+// within the current executable to the `OxidizedFinder` whose `path_hook`
+// method created it. This is a private implementation detail.
+py_class!(class _PathEntryFinder |py| {
+    // A `importlib.abc.MetaPathFinder`, presumably but not necessarily an
+    // `OxidizedFinder`. However, `_PathEntryFinder::iter_modules` will raise
+    // a `TypeError` when called if `finder` is not an `OxidizedFinder`.
+    data finder: PyObject;
+    // A list containing a single either str or bytes, normalized from the `path`
+    // argument to `OxidizedFinder::path_hook`.
+    data path: PyList;
+    // If the entry of `path` is `os.path.join(sys.executable, "pkg", "mod")`,
+    // then `package` is `"pkg.mod"`.
+    data package: String;
+
+    def find_spec(&self, fullname: &str, target: Option<PyModule> = None) -> PyResult<Option<PyObject>> {
+        self.find_spec_impl(py, fullname, target)
+    }
+
+    def invalidate_caches(&self) -> PyResult<PyObject> {
+        self.finder(py).call_method(py, "invalidate_caches", NoArgs, None)
+    }
+
+    def iter_modules(&self, prefix: Option<&str> = None) -> PyResult<PyList> {
+        self.iter_modules_impl(py, prefix)
+    }
+
+    // Private getter. Just for testing.
+    @property def _package(&self) -> PyResult<String> {
+        Ok(self.package(py).clone())
+    }
+});
+
+impl _PathEntryFinder {
+    // `name` is considered _visible_ in `package` if `name` is in the first
+    // level of the package. The computation is purely textual. See this
+    // module's `test_path_entry_finder::test_is_visible` test.
+    fn is_visible(package: &str, name: &str) -> bool {
+        if package.starts_with('.') || package.ends_with('.') || package.contains("..") {
+            return false;
+        }
+        // This implementation can be simplified when str::rsplit_once stabilize
+        // https://doc.rust-lang.org/std/primitive.str.html#method.rsplit_once
+        let mut split = name.rsplitn(2, '.');
+        match split.next() {
+            Some(module) if !module.is_empty() && !module.contains('.') => {}
+            _ => {
+                return false;
+            }
+        }
+        match split.next() {
+            Some(pkg) if !package.is_empty() && pkg == package => true,
+            None if package.is_empty() => true,
+            _ => false,
+        }
+    }
+
+    fn find_spec_impl(
+        &self,
+        py: Python,
+        fullname: &str,
+        target: Option<PyModule>,
+    ) -> PyResult<Option<PyObject>> {
+        if !_PathEntryFinder::is_visible(self.package(py), fullname) {
+            return Ok(Some(py.None()));
+        }
+        self.finder(py)
+            .call_method(py, "find_spec", (fullname, self.path(py), target), None)
+            .map(|spec| if spec == py.None() { None } else { Some(spec) })
+    }
+
+    fn iter_modules_impl(&self, py: Python, prefix: Option<&str>) -> PyResult<PyList> {
+        let state = self.finder(py).cast_as::<OxidizedFinder>(py)?.state(py);
+        let modules = state.get_resources_state().pkgutil_modules_infos(
+            py,
+            prefix.map(|p| p.to_string()),
+            state.optimize_level,
+            |resource| _PathEntryFinder::is_visible(self.package(py), &resource.name),
+        );
+        // unwrap() is safe because pkgutil_modules_infos returns a PyList cast
+        // into a PyObject.
+        Ok(modules?.cast_into(py).unwrap())
+    }
+
+    // Transform b"pkg/mod" into "pkg.mod" on behalf of `OxidizedFinder::path_hook`.
+    // Raise an `ImportError` if decoding `path` fails.
+    fn parse_path_to_pkg(py: Python, path: &std::path::Path) -> PyResult<String> {
+        let mut pkg = Vec::new();
+        for part in path.iter() {
+            pkg.push(
+                // Use Python's filesystem encoding to ensure correctly
+                // round-tripping the str Python package name from the
+                // potentially non-Unicode path.
+                // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_170
+                // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+                crate::conversion::path_to_pyobject(py, std::path::Path::new(part))?
+                    .cast_as::<PyString>(py)?
+                    .to_string(py)
+                    .map_err(|mut unicode_err| {
+                        // Need to raise an ImportError if can't decode. For
+                        // clarity, we also attach the UnicodeDecodeError.
+                        // https://docs.python.org/3/reference/import.html#path-entry-finders
+                        let mut imp_err = PyErr::new::<ImportError, _>(py, "cannot decode path");
+                        let imp_exc = imp_err.instance(py);
+                        if let Err(err) = imp_exc.setattr(py, "__suppress_context__", true) {
+                            err
+                        } else if let Err(err) =
+                            imp_exc.setattr(py, "__cause__", unicode_err.instance(py))
+                        {
+                            err
+                        } else {
+                            imp_err
+                        }
+                    })?
+                    .into_owned(),
+            );
+        }
+        Ok(pkg.join("."))
     }
 }
 
@@ -1466,17 +1675,16 @@ fn module_init(py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-/// Replace all meta path importers with an OxidizedFinder instance.
+/// Replace all meta path importers with an OxidizedFinder instance and return it.
 ///
 /// This is called after PyInit_* to finish the initialization of the
-/// module. Its state struct is updated. A new instance of the meta path
-/// importer is constructed and registered on sys.meta_path.
+/// module. Its state struct is updated.
 #[cfg(not(library_mode = "extension"))]
 pub(crate) fn replace_meta_path_importers<'a>(
     py: Python,
     m: &PyModule,
     resources_state: Box<PythonResourcesState<'a, u8>>,
-) -> PyResult<()> {
+) -> PyResult<PyObject> {
     let mut state = get_module_state(py, m)?;
 
     let sys_module = py.import("sys")?;
@@ -1494,5 +1702,99 @@ pub(crate) fn replace_meta_path_importers<'a>(
 
     state.initialized = true;
 
-    Ok(())
+    Ok(unified_importer.into_object())
+}
+
+/// Append [`OxidizedFinder::path_hook`] to [`sys.path_hooks`].
+///
+/// `sys` must be a reference to the [`sys`] module.
+///
+/// [`sys.path_hooks`]: https://docs.python.org/3/library/sys.html#sys.path_hooks
+/// [`sys`]: https://docs.python.org/3/library/sys.html
+#[cfg(not(library_mode = "extension"))]
+pub(crate) fn initialize_path_hooks(py: Python, finder: &PyObject, sys: &PyModule) -> PyResult<()> {
+    let hook = finder.getattr(py, "path_hook")?;
+    sys.get(py, "path_hooks")?
+        .call_method(py, "append", (hook,), None)
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod test_path_entry_finder {
+    use super::_PathEntryFinder;
+
+    #[test]
+    fn is_visible() {
+        let is_visible = _PathEntryFinder::is_visible;
+        // The empty package name allows top-level imports.
+        assert!(is_visible("", "importlib"));
+
+        // Any module on the first nesting level of a package are visible.
+        // panic!("am i alive?")
+        assert!(is_visible("importlib", "importlib.resources"));
+        assert!(is_visible("importlib", "importlib.machinery"));
+        assert!(is_visible("importlib", "importlib._private"));
+
+        // Modules a level lower or higher than the first level inside a package are invisible.
+        assert!(!is_visible("importlib", "importlib.machinery.internal"));
+        assert!(!is_visible("", "importlib.resources"));
+        assert!(!is_visible("importlib", "importlib"));
+
+        // Modules in different packages than `package` are invisible.
+        assert!(!is_visible("idlelib", "importlib.resources"));
+        assert!(!is_visible("imp", "importlib.resources"));
+
+        // Malformed package names always cause `is_visible` to return [`false`].
+        assert!(!is_visible(".a.b", ".a.b.c"));
+        assert!(!is_visible("a..b", "a..b.c"));
+        assert!(!is_visible("a.b.", "a.b.c"));
+        assert!(!is_visible(".", "a"));
+
+        // Unicode is fully supported.
+        assert!(is_visible("חבילות", "חבילות.מודול"));
+    }
+
+    /// _PathEntryFinder::parse_path_to_pkg re-encodes the package part of the
+    /// path with Python's filesystem encoding, rather than forcing UTF-8.
+    ///
+    /// Decoding "\u3030" (WAVY DASH) into UTF-16-LE and encoding the result
+    /// with UTF-8 returns the two-character sequence "00". So we set the
+    /// filesystem encoding to UTF-16-LE, pass in os.fsencode("\u3030"), and
+    /// ensure we get "\u3030" back out.
+    #[test]
+    fn parse_path_to_pkg_filesystem_encoding() {
+        // Obtain a Python interpreter with filesystem encoding set to UTF-16-LE
+        let mut config = crate::OxidizedPythonInterpreterConfig::default();
+        config.interpreter_config.parse_argv = Some(false);
+        config.set_missing_path_configuration = false;
+        config.interpreter_config.filesystem_encoding = Some("UTF-16-LE".to_string());
+        let mut interp = crate::MainPythonInterpreter::new(config).unwrap();
+        let py = interp.acquire_gil().unwrap();
+
+        // Verify assumptions about the test itself.
+        const WAVY_DASH: &str = "〰";
+        const WAVY_DASH_CODE: u16 = 0x3030;
+        assert_eq!(WAVY_DASH, "\u{3030}");
+        assert_eq!(
+            WAVY_DASH.encode_utf16().collect::<Vec<u16>>(),
+            [WAVY_DASH_CODE]
+        );
+        assert_eq!(WAVY_DASH_CODE.to_be_bytes(), [48, 48]); // endianness
+        assert_eq!(WAVY_DASH_CODE.to_le_bytes(), [48, 48]); // doesn't matter
+        assert_eq!(std::str::from_utf8(&[48, 48]).unwrap(), "00");
+        assert_eq!(
+            py.import("sys")
+                .unwrap()
+                .call(py, "getfilesystemencoding", cpython::NoArgs, None)
+                .unwrap()
+                .to_string(),
+            "utf-16-le"
+        );
+
+        // The actual test.
+        assert_eq!(
+            _PathEntryFinder::parse_path_to_pkg(py, std::path::Path::new("00")).unwrap(),
+            WAVY_DASH
+        );
+    }
 }

--- a/pyembed/src/importer.rs
+++ b/pyembed/src/importer.rs
@@ -994,13 +994,12 @@ impl OxidizedFinder {
                 .collect::<std::path::PathBuf>();
             _PathEntryFinder::parse_path_to_pkg(py, &tail)?
         };
-        let finder = OxidizedFinder::create_instance(py, Arc::clone(self.state(py)))?;
         // sys.path_hooks is only read after importlib._bootstrap_internal has
         // been setup, either in that module or after initialization by
         // PyImport_GetImporter checking for the existence of config->run_filename
         // has been setup, so it's safe to import os now.
         let paths = PyList::new(py, &[py.import("os")?.call(py, "fspath", (path,), None)?]);
-        _PathEntryFinder::create_instance(py, finder.into_object(), paths, pkg)
+        _PathEntryFinder::create_instance(py, self.as_object().clone_ref(py), paths, pkg)
     }
 }
 

--- a/pyembed/src/importer.rs
+++ b/pyembed/src/importer.rs
@@ -1719,7 +1719,7 @@ pub(crate) fn initialize_path_hooks(py: Python, finder: &PyObject, sys: &PyModul
 
 #[cfg(test)]
 mod test_path_entry_finder {
-    use super::{PathEntryFinder, oxidized_finder_new};
+    use super::{oxidized_finder_new, PathEntryFinder};
 
     #[test]
     fn is_visible() {

--- a/pyembed/src/importer.rs
+++ b/pyembed/src/importer.rs
@@ -1040,7 +1040,7 @@ py_class!(class _PathEntryFinder |py| {
 impl _PathEntryFinder {
     // `name` is considered _visible_ in `package` if `name` is in the first
     // level of the package. The computation is purely textual. See this
-    // module's `test_path_entry_finder::test_is_visible` test.
+    // module's `test_path_entry_finder::is_visible` test.
     fn is_visible(package: &str, name: &str) -> bool {
         if package.starts_with('.') || package.ends_with('.') || package.contains("..") {
             return false;

--- a/pyembed/src/importer.rs
+++ b/pyembed/src/importer.rs
@@ -1074,7 +1074,7 @@ impl _PathEntryFinder {
         fullname: &str,
         target: Option<PyModule>,
     ) -> PyResult<Option<PyObject>> {
-        if !_PathEntryFinder::is_visible(self.package(py), fullname) {
+        if !Self::is_visible(self.package(py), fullname) {
             return Ok(Some(py.None()));
         }
         self.finder(py)
@@ -1088,7 +1088,7 @@ impl _PathEntryFinder {
             py,
             Some(prefix.to_string()),
             state.optimize_level,
-            |resource| _PathEntryFinder::is_visible(self.package(py), &resource.name),
+            |resource| Self::is_visible(self.package(py), &resource.name),
         );
         // unwrap() is safe because pkgutil_modules_infos returns a PyList cast
         // into a PyObject.

--- a/pyembed/src/interpreter.rs
+++ b/pyembed/src/interpreter.rs
@@ -10,8 +10,8 @@ use {
         conversion::osstring_to_bytes,
         error::NewInterpreterError,
         importer::{
-            replace_meta_path_importers, PyInit_oxidized_importer, OXIDIZED_IMPORTER_NAME,
-            OXIDIZED_IMPORTER_NAME_STR, initialize_path_hooks,
+            initialize_path_hooks, replace_meta_path_importers, PyInit_oxidized_importer,
+            OXIDIZED_IMPORTER_NAME, OXIDIZED_IMPORTER_NAME_STR,
         },
         osutils::resolve_terminfo_dirs,
         pyalloc::PythonMemoryAllocator,
@@ -203,15 +203,17 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
             // is dropped. However, that would require self to be dropped. And if self is dropped,
             // there should no longer be a Python interpreter around. So it follows that the
             // importer state cannot be dropped after self.
-            Some(replace_meta_path_importers(py, &oxidized_importer, resources_state).map_err(
-                |err| {
-                    NewInterpreterError::new_from_pyerr(
-                        py,
-                        err,
-                        "initialization of oxidized importer",
-                    )
-                },
-            )?)
+            Some(
+                replace_meta_path_importers(py, &oxidized_importer, resources_state).map_err(
+                    |err| {
+                        NewInterpreterError::new_from_pyerr(
+                            py,
+                            err,
+                            "initialization of oxidized importer",
+                        )
+                    },
+                )?,
+            )
         } else {
             None
         };
@@ -228,9 +230,9 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
             ));
         }
 
-        let sys_module = py.import("sys").map_err(|err| {
-            NewInterpreterError::new_from_pyerr(py, err, "obtaining sys module")
-        })?;
+        let sys_module = py
+            .import("sys")
+            .map_err(|err| NewInterpreterError::new_from_pyerr(py, err, "obtaining sys module"))?;
         // When the main initialization ran, it initialized the "external"
         // importer (importlib._bootstrap_external). Our meta path importer
         // should have been registered first and would have been used for

--- a/pyembed/src/interpreter.rs
+++ b/pyembed/src/interpreter.rs
@@ -11,7 +11,7 @@ use {
         error::NewInterpreterError,
         importer::{
             replace_meta_path_importers, PyInit_oxidized_importer, OXIDIZED_IMPORTER_NAME,
-            OXIDIZED_IMPORTER_NAME_STR,
+            OXIDIZED_IMPORTER_NAME_STR, initialize_path_hooks,
         },
         osutils::resolve_terminfo_dirs,
         pyalloc::PythonMemoryAllocator,
@@ -189,7 +189,7 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
         let py = unsafe { Python::assume_gil_acquired() };
         self.py = Some(py);
 
-        if self.config.oxidized_importer {
+        let finder = if self.config.oxidized_importer {
             let resources_state = Box::new(PythonResourcesState::try_from(&self.config)?);
 
             let oxidized_importer = py.import(OXIDIZED_IMPORTER_NAME_STR).map_err(|err| {
@@ -203,7 +203,7 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
             // is dropped. However, that would require self to be dropped. And if self is dropped,
             // there should no longer be a Python interpreter around. So it follows that the
             // importer state cannot be dropped after self.
-            replace_meta_path_importers(py, &oxidized_importer, resources_state).map_err(
+            Some(replace_meta_path_importers(py, &oxidized_importer, resources_state).map_err(
                 |err| {
                     NewInterpreterError::new_from_pyerr(
                         py,
@@ -211,8 +211,10 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
                         "initialization of oxidized importer",
                     )
                 },
-            )?;
-        }
+            )?)
+        } else {
+            None
+        };
 
         // Now proceed with the Python main initialization. This will initialize
         // importlib. And if the custom importlib bytecode was registered above,
@@ -226,6 +228,9 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
             ));
         }
 
+        let sys_module = py.import("sys").map_err(|err| {
+            NewInterpreterError::new_from_pyerr(py, err, "obtaining sys module")
+        })?;
         // When the main initialization ran, it initialized the "external"
         // importer (importlib._bootstrap_external). Our meta path importer
         // should have been registered first and would have been used for
@@ -237,9 +242,6 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
         // controls both internal and external bootstrap modules and when
         // set it will disable a lot of "main" initialization.
         if !self.config.filesystem_importer {
-            let sys_module = py.import("sys").map_err(|err| {
-                NewInterpreterError::new_from_pyerr(py, err, "obtaining sys module")
-            })?;
             let meta_path = sys_module.get(py, "meta_path").map_err(|err| {
                 NewInterpreterError::new_from_pyerr(py, err, "obtaining sys.meta_path")
             })?;
@@ -248,6 +250,17 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
                 .map_err(|err| {
                     NewInterpreterError::new_from_pyerr(py, err, "sys.meta_path.pop()")
                 })?;
+        } else if let Some(finder) = finder {
+            // If we have both OxidizedFinder and PathFinder, we tell PathFinder
+            // how to use OxidizedFinder by inserting OxidizedFinder.path_hook
+            // into sys.path_hooks
+            initialize_path_hooks(py, &finder, &sys_module).map_err(|err| {
+                NewInterpreterError::new_from_pyerr(
+                    py,
+                    err,
+                    "installing OxidizedFinder in sys.path_hooks",
+                )
+            })?
         }
 
         /* Pre-initialization functions we could support:

--- a/pyembed/src/python_resources.rs
+++ b/pyembed/src/python_resources.rs
@@ -959,10 +959,11 @@ impl<'a> PythonResourcesState<'a, u8> {
             })
             .filter(predicate)
             .map(|r| {
+                let name = r.name.rsplit('.').take(1).next().unwrap();
                 let name = if let Some(prefix) = &prefix {
-                    format!("{}{}", prefix, r.name)
+                    format!("{}{}", prefix, name)
                 } else {
-                    r.name.to_string()
+                    name.to_string()
                 };
 
                 let name = name.to_py_object(py).into_object();

--- a/pyembed/src/test/importer.rs
+++ b/pyembed/src/test/importer.rs
@@ -168,4 +168,10 @@ rusty_fork_test! {
     fn importer_resource_reading_py() {
         run_py_test("test_importer_resource_reading.py").unwrap()
     }
+
+    /// Run test_importer_path_entry_finder.py.
+    #[test]
+    fn importer_path_entry_finder_py() {
+        run_py_test("test_importer_path_entry_finder.py").unwrap()
+    }
 }

--- a/pyembed/src/test/interpreter_config.rs
+++ b/pyembed/src/test/interpreter_config.rs
@@ -49,7 +49,7 @@ fn assert_importer(oxidized: bool, filesystem: bool) {
     config.filesystem_importer = filesystem;
     let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-    let py = interp.acquire_gil().unwrap();
+    let py = interp.acquire_gil();
     let sys = py.import("sys").unwrap();
     let meta_path_reprs = reprs(py, &sys.get(py, "meta_path").unwrap()).unwrap();
     let path_hook_reprs = reprs(py, &sys.get(py, "path_hooks").unwrap()).unwrap();

--- a/pyembed/src/test/test_importer_iter_modules.py
+++ b/pyembed/src/test/test_importer_iter_modules.py
@@ -108,28 +108,62 @@ class TestImporterIterModules(unittest.TestCase):
         self.assertEqual(res[0].name, "foomy_package")
         self.assertTrue(res[0].ispkg)
 
+    def test_iter_modules_nested(self):
+        self._make_package("a.b")
+        (self.td / "one.py").touch()
+
+        f = self._finder_from_td()
+
+        expected = [("a", True), ("one", False)]
+        self.assertCountEqual(f.iter_modules(), expected)
+
+        sys.meta_path = [f]
+        sys.path = []
+        res = list(pkgutil.iter_modules())
+        self.assertCountEqual([(mi.name, mi.ispkg) for mi in res], expected)
+        for mi in res:
+            self.assertIs(mi.module_finder, f)
+
     def test_iter_modules_path(self):
         self._make_package("a.b.c")
         self._make_package("one.two.three")
         self._make_package("on.tשo.۳")
         self._make_package("on.two")
-        path = pathlib.Path(sys.executable, "on")
-        finder = self._finder_from_td()
-        path_entry_finder = finder.path_hook(path)
-        _PathEntryFinder = type(path_entry_finder)
-        modules = path_entry_finder.iter_modules()
-        self.assertCountEqual(modules, [("on.two", True), ("on.tשo", True)])
 
-        sys.meta_path = [finder]
-        import on
-        self.assertEqual(on.__path__, [str(path)])
+        f = self._finder_from_td()
+
+        name = "on"
+        path = pathlib.Path(sys.executable, name)
+        path_entry_finder = f.path_hook(path)
+
+        with self.subTest(prefix="", module_iterator="_PathEntryFinder"):
+            unprefixed = path_entry_finder.iter_modules()
+            self.assertCountEqual(unprefixed, [("two", True), ("tשo", True)])
+
+        prefix = name + "."
+        with self.subTest(prefix=name + ".", module_iterator="_PathEntryFinder"):
+            prefixed = path_entry_finder.iter_modules(prefix=prefix)
+            self.assertCountEqual(prefixed, [("on.two", True), ("on.tשo", True)])
+
+        def assert_iter_modules(prefix: str, expected, *args):
+            with self.subTest(prefix=prefix, module_iterator="pkgutil"):
+                res = list(pkgutil.iter_modules(*args))
+                self.assertCountEqual([(mi.name, mi.ispkg) for mi in res], expected)
+                for mi in res:
+                    self.assertIsInstance(mi.module_finder, type(path_entry_finder))
+                    self.assertEqual(
+                        mi.module_finder._package, path_entry_finder._package)
+
         sys.path = [sys.executable]
-        with patch.object(sys, "path_hooks", [finder.path_hook]):
-            res = list(pkgutil.iter_modules([path]))
-            self.assertCountEqual([(mi.name, mi.ispkg) for mi in res], modules)
-            for mi in res:
-                self.assertIsInstance(mi, pkgutil.ModuleInfo)
-                self.assertIsInstance(mi.module_finder, _PathEntryFinder)
+        sys.meta_path = [f]
+        with patch.dict(sys.modules):
+            import on
+            self.assertEqual(on.__name__, name)
+            self.assertEqual(on.__path__, [str(path)])
+            with patch.object(sys, "path_hooks", [f.path_hook]):
+                assert_iter_modules("", unprefixed, on.__path__)
+                prefix = on.__name__ + "."
+                assert_iter_modules(prefix, prefixed, on.__path__, prefix)
 
 
 if __name__ == "__main__":

--- a/pyembed/src/test/test_importer_iter_modules.py
+++ b/pyembed/src/test/test_importer_iter_modules.py
@@ -136,12 +136,12 @@ class TestImporterIterModules(unittest.TestCase):
         path = pathlib.Path(sys.executable, name)
         path_entry_finder = f.path_hook(path)
 
-        with self.subTest(prefix="", module_iterator="_PathEntryFinder"):
+        with self.subTest(prefix="", module_iterator="PathEntryFinder"):
             unprefixed = path_entry_finder.iter_modules()
             self.assertCountEqual(unprefixed, [("two", True), ("tשo", True)])
 
         prefix = name + "."
-        with self.subTest(prefix=name + ".", module_iterator="_PathEntryFinder"):
+        with self.subTest(prefix=name + ".", module_iterator="PathEntryFinder"):
             prefixed = path_entry_finder.iter_modules(prefix=prefix)
             self.assertCountEqual(prefixed, [("on.two", True), ("on.tשo", True)])
 

--- a/pyembed/src/test/test_importer_module.py
+++ b/pyembed/src/test/test_importer_module.py
@@ -55,6 +55,7 @@ class TestImporterModule(unittest.TestCase):
                 "indexed_resources",
                 "invalidate_caches",
                 "iter_modules",
+                "path_hook",
                 "serialize_indexed_resources",
             },
         )

--- a/pyembed/src/test/test_importer_module.py
+++ b/pyembed/src/test/test_importer_module.py
@@ -20,6 +20,7 @@ class TestImporterModule(unittest.TestCase):
                 "OxidizedResourceCollector",
                 "OxidizedResourceReader",
                 "OxidizedResource",
+                "PathEntryFinder",
                 "PythonExtensionModule",
                 "PythonModuleBytecode",
                 "PythonModuleSource",

--- a/pyembed/src/test/test_importer_path_entry_finder.py
+++ b/pyembed/src/test/test_importer_path_entry_finder.py
@@ -120,8 +120,9 @@ class TestImporterPathEntryFinder(unittest.TestCase):
         self.assertIsNone(finder.find_spec("on.tשo.۳"))
         # Return a correct ModuleSpec for modules in the search path
         self.assert_spec(finder.find_spec("on.tשo"), "on.tשo", is_pkg=True)
-        # Find the same module from iter_modules()
-        self.assertCountEqual(finder.iter_modules(""), [("on.tשo", True)])
+        # Find the same module from iter_modules(), without and with a prefix
+        self.assertCountEqual(finder.iter_modules(), [("tשo", True)])
+        self.assertCountEqual(finder.iter_modules("on."), [("on.tשo", True)])
 
     def test_find_spec_nested_abs_str(self):
         self.assert_find_spec_nested(os.path.join(sys.executable, "on"))
@@ -142,7 +143,7 @@ class TestImporterPathEntryFinder(unittest.TestCase):
     def assert_find_spec_top_level(self, path: Union[str, bytes, os.PathLike]) -> None:
         finder = self.finder(path, "")
         modules = [("a", True), ("one", True), ("on", True)]
-        self.assertCountEqual(finder.iter_modules(""), modules)
+        self.assertCountEqual(finder.iter_modules(), modules)
         for name, is_pkg in modules:
             self.assert_spec(finder.find_spec(name), name, is_pkg)
         for name in "a.b", "a.b.c", "on.tשo", "on.tשo.۳":
@@ -162,7 +163,7 @@ class TestImporterPathEntryFinder(unittest.TestCase):
     def assert_unicode_path(self, path: Union[str, bytes, os.PathLike]) -> None:
         finder = self.finder(path, "on.tשo")
         self.assert_spec(finder.find_spec("on.tשo.۳"), "on.tשo.۳", is_pkg=False)
-        self.assertCountEqual(finder.iter_modules(""), [("on.tשo.۳", False)])
+        self.assertCountEqual(finder.iter_modules(), [("۳", False)])
 
     def test_unicode_path_abs_str(self):
         self.assert_unicode_path(os.path.join(sys.executable,"on", "tשo"))

--- a/pyembed/src/test/test_importer_path_entry_finder.py
+++ b/pyembed/src/test/test_importer_path_entry_finder.py
@@ -1,0 +1,270 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+from contextlib import contextmanager
+from importlib.machinery import PathFinder
+import marshal
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+from typing import Iterable, Optional, Tuple, Union, TYPE_CHECKING
+import unittest
+from unittest.mock import patch
+
+from oxidized_importer import OxidizedFinder, OxidizedResource
+
+if TYPE_CHECKING:
+    import importlib.abc
+    from importlib.machinery import ModuleSpec
+
+
+def make_finder(*modules: Tuple[str, str, bool]) -> OxidizedFinder:
+    """Create an ``OxidizedFinder`` with modules defined by ``modules``.
+
+    ``modules`` must be tuples of the form (name, source_code, is_package).
+    """
+    mpf = OxidizedFinder()
+    for module_name, source, is_pkg in modules:
+        # See example in OxidizedFinder.add_resource
+        resource = OxidizedResource()
+        resource.is_module = True
+        resource.name = module_name
+        resource.is_package = is_pkg
+        resource.in_memory_source = source.encode("utf-8")
+        resource.in_memory_bytecode = marshal.dumps(compile(
+            source, module_name, "exec"))
+        mpf.add_resource(resource)
+    return mpf
+
+
+@contextmanager
+def chdir(dir: Union[str, bytes, os.PathLike]) -> Iterable[Path]:
+    "Change the current directory to ``dir``, yielding the previous one."
+    old_cwd = Path.cwd()
+    try:
+        os.chdir(dir)
+        yield old_cwd
+    finally:
+        os.chdir(old_cwd)
+
+
+class TestImporterPathEntryFinder(unittest.TestCase):
+
+    def finder(
+        self,
+        path: Union[str, bytes, os.PathLike],
+        package: str,
+    ) -> importlib.abc.PathEntryFinder:
+        """Add the following package hierarchy to the returned finder:
+
+        - ``a`` imports ``a.b`` imports ``a.b.c``
+        - ``one`` imports ``three`` from ``.two``; ``one.two`` imports
+          ``one.two.three``.
+        - ``on``, ``on.tשo``, and ``on.tשo.۳`` each pass
+        """
+        mpf = make_finder(
+            ("a", "import a.b", True),
+            ("a.b", "import a.b.c", True),
+            ("a.b.c", "pass", False),
+
+            ("one", "from .two import three", True),
+            ("one.two", "import one.two.three", True),
+            ("one.two.three", "pass", False),
+
+            ("on", "pass", True),
+            ("on.tשo", "pass", True),
+            ("on.tשo.۳", "pass", False),
+        )
+        pef = mpf.path_hook(path)
+        self.assertEqual(pef._package, package)
+        self.assertRaises(AttributeError, setattr, pef, "_package", package)
+        return pef
+
+    def assert_spec(
+        self,
+        spec: ModuleSpec,
+        name: str,
+        is_pkg: bool,
+        Loader: importlib.abc.Loader = OxidizedFinder,
+        origin: Optional[str] = None
+    ) -> None:
+        self.assertIsNotNone(spec, name)
+        self.assertEqual(spec.name, name, spec)
+        self.assertTrue(
+            isinstance(spec.loader, Loader) or issubclass(spec.loader, Loader),
+            spec)
+        self.assertEqual(spec.origin, origin, spec)
+        self.assertIsNone(spec.cached, spec)
+        self.assertFalse(spec.has_location, spec)
+        if is_pkg:
+            self.assertIsNotNone(spec.submodule_search_locations, spec)
+            for entry in spec.submodule_search_locations:
+                self.assertIsInstance(entry, (str, bool), spec)
+            self.assertEqual(spec.parent, name, spec)
+        else:
+            self.assertIsNone(spec.submodule_search_locations, spec)
+            self.assertEqual(spec.parent, name.rpartition(".")[0], spec)
+
+    def assert_find_spec_nested(self, path: Union[str, bytes, os.PathLike]) -> None:
+        finder = self.finder(path, "on")
+        # Return None for modules outside the search path, even if their names
+        # are prefixed by the path.
+        self.assertIsNone(finder.find_spec("one.two"))
+        # Return None for modules shallower than the search path
+        self.assertIsNone(finder.find_spec("on"))
+        # Return None for modules deeper than the search path
+        self.assertIsNone(finder.find_spec("on.tשo.۳"))
+        # Return a correct ModuleSpec for modules in the search path
+        self.assert_spec(finder.find_spec("on.tשo"), "on.tשo", is_pkg=True)
+        # Find the same module from iter_modules()
+        self.assertCountEqual(finder.iter_modules(""), [("on.tשo", True)])
+
+    def test_find_spec_nested_abs_str(self):
+        self.assert_find_spec_nested(os.path.join(sys.executable, "on"))
+
+    def test_find_spec_nested_rel_str(self):
+        exe = Path(sys.executable)
+        with chdir(exe.parent):
+            self.assert_find_spec_nested(str(Path("..", exe.parent.name, exe.name, "on")))
+
+    def test_find_spec_nested_abs_pathlike(self):
+        self.assert_find_spec_nested(Path(sys.executable, "on"))
+
+    def test_find_spec_nested_rel_bytes(self):
+        exe = Path(sys.executable)
+        with chdir(exe.parent):
+            self.assert_find_spec_nested(bytes(Path("..", exe.parent.name, exe.name, "on")))
+
+    def assert_find_spec_top_level(self, path: Union[str, bytes, os.PathLike]) -> None:
+        finder = self.finder(path, "")
+        modules = [("a", True), ("one", True), ("on", True)]
+        self.assertCountEqual(finder.iter_modules(""), modules)
+        for name, is_pkg in modules:
+            self.assert_spec(finder.find_spec(name), name, is_pkg)
+        for name in "a.b", "a.b.c", "on.tשo", "on.tשo.۳":
+            self.assertIsNone(finder.find_spec(name))
+
+    def test_find_spec_top_level_abs_str(self):
+        self.assert_find_spec_top_level(sys.executable)
+
+    def test_find_spec_top_level_abs_bytes(self):
+        self.assert_find_spec_top_level(os.fsencode(sys.executable))
+
+    def test_find_spec_top_level_rel_str(self):
+        exe = Path(sys.executable)
+        with chdir(exe.parent):
+            self.assert_find_spec_top_level(exe.name)
+
+    def assert_unicode_path(self, path: Union[str, bytes, os.PathLike]) -> None:
+        finder = self.finder(path, "on.tשo")
+        self.assert_spec(finder.find_spec("on.tשo.۳"), "on.tשo.۳", is_pkg=False)
+        self.assertCountEqual(finder.iter_modules(""), [("on.tשo.۳", False)])
+
+    def test_unicode_path_abs_str(self):
+        self.assert_unicode_path(os.path.join(sys.executable,"on", "tשo"))
+
+    def test_unicode_path_abs_bytes(self):
+        self.assert_unicode_path(os.fsencode(os.path.join(sys.executable,"on", "tשo")))
+
+    def test_unicode_path_rel_pathlike(self):
+        exe = Path(sys.executable)
+        with chdir(exe.parent):
+            self.assert_unicode_path(Path(exe.name, "on", "tשo"))
+
+    def test_unicode_path_rel_bytes(self):
+        exe = Path(sys.executable)
+        with chdir(exe.parent):
+            self.assert_unicode_path(bytes(Path(exe.name, "on", "tשo")))
+
+    def test_empty_finder_abs_str(self):
+        self.assertIsNone(OxidizedFinder().path_hook(sys.executable).find_spec("a"))
+
+    def test_non_existent_pkg_abs_str(self):
+        path = os.path.join(sys.executable, "foo", "bar")
+        finder = self.finder(path, "foo.bar")
+        self.assertIsNone(finder.find_spec("foo.bar.baz"))
+
+    def test_non_existent_pkg_rel_str(self):
+        exe = Path(sys.executable)
+        with chdir(exe.parent):
+            path = os.path.join("..", exe.parent.name, exe.name, "foo", "bar")
+            finder = self.finder(path, "foo.bar")
+            self.assertIsNone(finder.find_spec("foo.bar.baz"))
+
+    def test_path_hook_installed(self):
+        # PathFinder can only use it with sys.executable on sys.path
+        with patch('sys.path', sys.path):
+            sys.path = [p for p in sys.path if p != sys.executable]
+            PathFinder.invalidate_caches()
+            self.assertIsNone(PathFinder.find_spec("pwd"))
+
+            sys.path.append(sys.executable)
+            spec = PathFinder.find_spec("pwd")
+        self.assert_spec(
+            spec, "pwd", is_pkg=False, Loader=sys.__spec__.loader,
+            origin="built-in")
+
+    ############################################################################
+    # Error Handling
+
+    NOT_FOUND_ERR = "path .* does not begin in .*"
+
+    def test_not_sys_executable_abs_str(self):
+        self.assertFalse(
+            sys.prefix.startswith(sys.executable), "bad assumption in test")
+        finder = OxidizedFinder()
+        with self.assertRaisesRegex(ImportError, self.NOT_FOUND_ERR) as cm:
+             finder.path_hook(sys.prefix)
+        self.assertEqual(cm.exception.path, sys.prefix)
+
+    def test_not_sys_executable_rel_str(self):
+        path = Path(Path(sys.executable).name, "a", "b")
+        with tempfile.TemporaryDirectory(prefix="oxidized_importer-test-") as td:
+            with chdir(td):
+                with self.assertRaisesRegex(ImportError, self.NOT_FOUND_ERR) as cm:
+                    self.finder(path, "a.b")
+                self.assertEqual(cm.exception.path, path)
+
+    def test_find_spec_no_path_arg(self):
+        finder = self.finder(Path(sys.executable, "a"), "a")
+        # finder.find_spec does not take a path arg
+        self.assertRaisesRegex(
+            TypeError, "takes at most 2 arguments", finder.find_spec, "a.b",
+            None, None)
+        self.assertRaisesRegex(
+            TypeError, "'path' is an invalid keyword argument",
+            finder.find_spec, "a.b", path=None)
+
+    def test_path_bad_type(self):
+        self.assertRaisesRegex(
+            TypeError, "expected str, bytes or os.PathLike object, not int",
+            OxidizedFinder().path_hook, 1)
+
+    def test_bad_unicode_executable_path_ok(self):
+        # A non-Unicode path doesn't cause a panic.
+        exe = sys.executable.encode("utf-8", "surrogatepass")
+        # "fo\ud800o" contains an unpaired surrogate.
+        foo = "fo\ud800o".encode("utf-8", "surrogatepass")
+        exe += foo
+        with self.assertRaises(ImportError) as cm:
+            OxidizedFinder().path_hook(exe)
+        self.assertEqual(cm.exception.path, exe)
+
+    @unittest.expectedFailure  # https://github.com/dgrunwald/rust-cpython/issues/246
+    def test_bad_utf8_pkg_name_raises(self):
+        exe = sys.executable.encode("utf-8", "surrogatepass")
+        foo = "fo\ud800o".encode("utf-8", "surrogatepass")
+        exe = os.path.join(exe, foo)
+        with self.assertRaisesRegex(ImportError, "cannot decode") as cm:
+            OxidizedFinder().path_hook(exe)
+        self.assertIsInstance(cm.exception.__cause__, UnicodeDecodeError)
+        self.assertIn(foo, cm.exception.__cause__.object)
+        self.assertEqual(cm.exception.__cause__.encoding.lower(), "utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyembed/src/test/test_importer_path_entry_finder.py
+++ b/pyembed/src/test/test_importer_path_entry_finder.py
@@ -16,7 +16,7 @@ from typing import Iterable, Optional, Tuple, Union, TYPE_CHECKING
 import unittest
 from unittest.mock import patch
 
-from oxidized_importer import OxidizedFinder, OxidizedResource
+from oxidized_importer import OxidizedFinder, OxidizedResource, PathEntryFinder
 
 if TYPE_CHECKING:
     import importlib.abc
@@ -69,7 +69,7 @@ def link_dir(src: PathLike, dst: PathLike) -> None:
 
 class TestImporterPathEntryFinder(unittest.TestCase):
 
-    def finder(self, path: PathLike, package: str) -> importlib.abc.PathEntryFinder:
+    def finder(self, path: PathLike, package: str) -> PathEntryFinder:
         """Add the following package hierarchy to the returned finder:
 
         - ``a`` imports ``a.b`` imports ``a.b.c``
@@ -91,6 +91,7 @@ class TestImporterPathEntryFinder(unittest.TestCase):
             ("on.tשo.۳", "pass", False),
         )
         pef = mpf.path_hook(path)
+        self.assertIsInstance(pef, PathEntryFinder)
         self.assertEqual(pef._package, package)
         self.assertRaises(AttributeError, setattr, pef, "_package", package)
         return pef


### PR DESCRIPTION
This PR is a rewrite of and supersedes #340, and it fixes #337.

# Summary

To make `pkgutil.iter_modules(pkg.__path__)` list only modules in `pkg`, I've added the `OxidizedFinder.path_hook` method, and, based on existing settings in `OxidizedPythonInterpreterConfig`, the `OxidizedFinder` instance in `sys.meta_path` has its bound `path_hook` method added to `sys.path_hooks`. When `pkgutil.iter_modules` passes `pkg.__path__` to `path_hook`, `path_hook` returns an `importlib.abc.PathEntryFinder` object whose `iter_modules` method searches the `OxidizedFinder` instance for embedded resources whose names identify them as being in `pkg`.

# Review

I think this is ready to go as long as you agree with me that none of the [known bugs](#known-bugs) are blockers. All tests pass on my Mac except tests that were failing before in `main` at 2b4e66406f4fafdd7e09bc469878b239dcd55880. I'll run tests on Windows this weekend or early next week.

# Known bugs

Multiple `OxidizedFinder` instances' `path_hook`s being in `sys.path_hooks` would interfere with each other.  The first one in `sys.path_hooks` wins control over all paths under `sys.executable`.

The `PathEntryFinder` that `OxidizedFinder.path_hook` returns does not (yet) implement legacy methods `find_loader` and `find_module`, which were deprecated in Python 3.4. They wouldn't be hard to write, but I'm having trouble convincing myself there's any point. I have confirmed that nothing in the standard library relies on those methods. If we really want those methods, I think they can be added in future PRs, and we can crib [Python's implementations](https://github.com/python/cpython/blob/550e4673be538d98b6ddf5550b3922539cf5c4b2/Lib/importlib/abc.py#L95-L127).

`OxidizedFinder.path_hook` panics when a path contains an unpaired surrogate after the `sys.executable` part of the path because of dgrunwald/rust-cpython#246. I added a `unittest.expectedFailure` test case for a `UnicodeDecodeError` being raised instead.

My algorithm for separating the `sys.executable` part of the path from the `pkg/mod` part of the path has some trash strewn about it. The worst bit is where I make a couple of allocations (`.collect<PathBuf>`) where really none are needed. Open to suggestions about how to tighten that up.

# UPDATE (12/22/20): Backwards incompatible change to achieve compatibility with CPython standard library

After some further testing I noticed that `pkgutil.iter_modules()` (i.e., with no `path` argument) was behaving differently when an `OxidizedFinder` was present on `sys.meta_path`. The standard library (vanilla CPython) yields only top-level modules (e.g., `importlib` but not `importlib.abc`). Moreover, the standard library only yields the last component of modules' `__name__`s:

```pycon
>>> import importlib, pkgutil
>>> [name for finder, name, ispkg in pkgutil.iter_modules(importlib.__path__)]
['_bootstrap', '_bootstrap_external', 'abc', 'machinery', 'metadata', 'resources', 'util']
```

02b9c2504960b3e53ea52eb2cf4224958f818d92 modifies `OxidizedFinder.iter_modules` and `OxidizedFinder().path_hook(path).iter_modules` to conform to the standard library's behavior. The documentation says almost nothing about a finder's `iter_modules` method, so the standard library is our best source of expected behavior.