### PR TITLE
pyembed: API: MainPythonInterpreter ownership prevents runtime errors

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -55,6 +55,8 @@ Backwards Compatibility Notes
 * ``show_alloc_count`` has been removed from types representing Python
   interpreter configuration because support for this feature was removed in
   Python 3.9.
+* ``pyembed::MainPythonInterpreter.acquire_gil()``'s signature has changed, now
+  returning a ``Python`` value directly without wrapping it in a ``Result``.
 
 Bug Fixes
 ^^^^^^^^^
@@ -72,6 +74,9 @@ Bug Fixes
 * The lifetime of ``pyembed::MainPythonInterpreter.acquire_gil()``'s return
   value has been adjusted so the Rust compiler will refuse to compile code
   that could crash due to attempting to use a finalized interpreter. (#345)
+* ``pyembed::MainPythonInterpreter.py_runmain()``'s signature has changed, now
+  consuming ownership of the receiver. Subsequent borrows of ``self`` now fail
+  to compile rather than causing runtime errors.
 
 New Features
 ^^^^^^^^^^^^

--- a/pyembed/docs/pyembed_controlling_python.rst
+++ b/pyembed/docs/pyembed_controlling_python.rst
@@ -24,7 +24,7 @@ use it:
 .. code-block:: rust
 
    fn do_it(interpreter: &MainPythonInterpreter) -> {
-       let py = interpreter.acquire_gil().unwrap();
+       let py = interpreter.acquire_gil();
 
        match py.eval("print('hello, world')") {
            Ok(_) => print("python code executed successfully"),

--- a/pyembed/src/interpreter.rs
+++ b/pyembed/src/interpreter.rs
@@ -74,14 +74,6 @@ impl From<RawAllocator> for InterpreterRawAllocator {
     }
 }
 
-#[derive(Debug, PartialEq)]
-enum InterpreterState {
-    NotStarted,
-    Initializing,
-    Initialized,
-    Finalized,
-}
-
 /// Manages an embedded Python interpreter.
 ///
 /// Python interpreters have global state and there can only be a single
@@ -100,7 +92,6 @@ pub struct MainPythonInterpreter<'python, 'interpreter: 'python, 'resources: 'in
     // It is possible to have a use-after-free if config is dropped before the
     // interpreter is finalized/dropped.
     config: ResolvedOxidizedPythonInterpreterConfig<'resources>,
-    interpreter_state: InterpreterState,
     interpreter_guard: Option<std::sync::MutexGuard<'interpreter, ()>>,
     raw_allocator: Option<InterpreterRawAllocator>,
     gil: Option<GILGuard>,
@@ -133,7 +124,6 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
         let mut res = MainPythonInterpreter {
             config,
             interpreter_guard: None,
-            interpreter_state: InterpreterState::NotStarted,
             raw_allocator: None,
             gil: None,
             py: None,
@@ -158,25 +148,10 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
     ///
     /// Returns a Python instance which has the GIL acquired.
     fn init(&mut self) -> Result<(), NewInterpreterError> {
-        match &self.interpreter_state {
-            InterpreterState::Initializing => {
-                return Err(NewInterpreterError::Simple(
-                    "interpreter in initializing state",
-                ))
-            }
-            InterpreterState::Initialized => {
-                return Ok(());
-            }
-            InterpreterState::NotStarted => {}
-            InterpreterState::Finalized => {}
-        }
-
         assert!(self.interpreter_guard.is_none());
         self.interpreter_guard = Some(GLOBAL_INTERPRETER_GUARD.lock().map_err(|_| {
             NewInterpreterError::Simple("unable to acquire global interpreter guard")
         })?);
-
-        self.interpreter_state = InterpreterState::Initializing;
 
         let origin_string = self.config.origin().display().to_string();
 
@@ -250,6 +225,7 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
         // inject our custom importer.
 
         let py = unsafe { Python::assume_gil_acquired() };
+        self.py = Some(py);
 
         if self.config.oxidized_importer {
             let resources_state = Box::new(PythonResourcesState::try_from(&self.config)?);
@@ -310,9 +286,6 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
          *
          * PyObject_SetArenaAllocator()
          */
-
-        self.py = Some(py);
-        self.interpreter_state = InterpreterState::Initialized;
 
         if self.config.argvb {
             let args_objs = self
@@ -415,10 +388,8 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
 
     /// Ensure the Python GIL is released.
     pub fn release_gil(&mut self) {
-        if self.py.is_some() {
-            self.py = None;
-            self.gil = None;
-        }
+        self.py = None;
+        self.gil = None;
     }
 
     /// Ensure the Python GIL is acquired, returning a handle on the interpreter.
@@ -427,21 +398,8 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
     /// instance. This is because `MainPythonInterpreter.drop()` finalizes
     /// the interpreter. The borrow checker should refuse to compile code
     /// where the returned `Python` outlives `self`.
-    pub fn acquire_gil(&mut self) -> Result<Python<'_>, &'static str> {
-        match self.interpreter_state {
-            InterpreterState::NotStarted => {
-                return Err("interpreter not initialized");
-            }
-            InterpreterState::Initializing => {
-                return Err("interpreter not fully initialized");
-            }
-            InterpreterState::Initialized => {}
-            InterpreterState::Finalized => {
-                return Err("interpreter is finalized");
-            }
-        }
-
-        Ok(match self.py {
+    pub fn acquire_gil(&mut self) -> Python<'_> {
+        match self.py {
             Some(py) => py,
             None => {
                 let gil = GILGuard::acquire();
@@ -452,10 +410,10 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
 
                 py
             }
-        })
+        }
     }
 
-    /// Runs `Py_RunMain()`.
+    /// Runs `Py_RunMain()` and finalizes the interpreter.
     ///
     /// This will execute whatever is configured by the Python interpreter config
     /// and return an integer suitable for use as a process exit code.
@@ -465,16 +423,8 @@ impl<'python, 'interpreter, 'resources> MainPythonInterpreter<'python, 'interpre
     /// an uncaught exception. If you want to keep the interpreter alive or inspect
     /// the evaluation result, consider calling a function on the interpreter handle
     /// that executes code.
-    pub fn py_runmain(&mut self) -> i32 {
-        let res = unsafe { pyffi::Py_RunMain() };
-
-        // Py_RunMain() finalizes the interpreter. So drop our refs and state.
-        self.interpreter_guard = None;
-        self.interpreter_state = InterpreterState::Finalized;
-        self.py = None;
-        self.gil = None;
-
-        res
+    pub fn py_runmain(self) -> i32 {
+        unsafe { pyffi::Py_RunMain() }
     }
 }
 
@@ -589,9 +539,7 @@ impl<'python, 'interpreter, 'resources> Drop
 {
     fn drop(&mut self) {
         if let Some(path) = self.write_modules_path.clone() {
-            let py = self.acquire_gil().unwrap();
-
-            if let Err(msg) = write_modules_to_path(py, &path) {
+            if let Err(msg) = write_modules_to_path(self.acquire_gil(), &path) {
                 eprintln!("error writing modules file: {}", msg);
             }
         }

--- a/pyembed/src/test/importer.rs
+++ b/pyembed/src/test/importer.rs
@@ -34,10 +34,8 @@ fn run_py_test(test_filename: &str) -> Result<()> {
     config.interpreter_config.run_filename = Some(test_path);
     config.interpreter_config.buffered_stdio = Some(false);
     config.set_missing_path_configuration = false;
-    let mut interp = MainPythonInterpreter::new(config)?;
 
-    let exit_code = interp.py_runmain();
-    if exit_code != 0 {
+    if MainPythonInterpreter::new(config)?.py_runmain() != 0 {
         Err(anyhow!("Python code did not exit successfully"))
     } else {
         Ok(())
@@ -45,7 +43,7 @@ fn run_py_test(test_filename: &str) -> Result<()> {
 }
 
 fn get_importer(interp: &mut MainPythonInterpreter) -> Result<PyObject> {
-    let py = interp.acquire_gil().unwrap();
+    let py = interp.acquire_gil();
 
     let sys = py.import("sys").unwrap();
     let meta_path = sys.get(py, "meta_path").unwrap();
@@ -69,7 +67,7 @@ rusty_fork_test! {
         config.set_missing_path_configuration = false;
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
         let meta_path = sys.get(py, "meta_path").unwrap();
         assert_eq!(meta_path.len(py).unwrap(), 2);
@@ -90,7 +88,7 @@ rusty_fork_test! {
     fn find_spec_missing() {
         let mut interp = new_interpreter().unwrap();
         let importer = get_importer(&mut interp).unwrap();
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
 
         assert_eq!(
             importer

--- a/pyembed/src/test/interpreter_config.rs
+++ b/pyembed/src/test/interpreter_config.rs
@@ -41,7 +41,7 @@ rusty_fork_test! {
         config.set_missing_path_configuration = false;
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
         let meta_path = sys.get(py, "meta_path").unwrap();
         assert_eq!(meta_path.len(py).unwrap(), 3);
@@ -72,7 +72,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
         let flags = sys.get(py, "flags").unwrap();
 
@@ -122,7 +122,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argv = sys
@@ -153,7 +153,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argv = sys
@@ -180,7 +180,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argv = sys
@@ -203,7 +203,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argvb_raw = sys.get(py, "argvb").unwrap();
@@ -235,7 +235,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argv_raw = sys.get(py, "argv").unwrap();
@@ -275,7 +275,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argv_raw = sys.get(py, "argv").unwrap();
@@ -338,7 +338,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let argv_raw = sys.get(py, "argv").unwrap();
@@ -399,7 +399,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -416,7 +416,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -433,7 +433,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -450,7 +450,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -467,7 +467,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -484,7 +484,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -501,7 +501,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -518,7 +518,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -535,7 +535,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -552,7 +552,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -569,7 +569,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -586,7 +586,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();
@@ -603,7 +603,7 @@ rusty_fork_test! {
 
         let mut interp = MainPythonInterpreter::new(config).unwrap();
 
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         let sys = py.import("sys").unwrap();
 
         let flags = sys.get(py, "flags").unwrap();

--- a/pyembed/src/test/main_python_interpreter.rs
+++ b/pyembed/src/test/main_python_interpreter.rs
@@ -14,7 +14,7 @@ rusty_fork_test! {
         config.interpreter_config.parse_argv = Some(false);
         config.set_missing_path_configuration = false;
         let mut interp = MainPythonInterpreter::new(config).unwrap();
-        let py = interp.acquire_gil().unwrap();
+        let py = interp.acquire_gil();
         py.import("sys").unwrap();
     }
 }


### PR DESCRIPTION
Previously, the `acquire_gil` method of a `MainPythonInterpreter` would return an `Err` if called after `py_runmain`. Coordinating this required a state type `InterpreterState`, which `MainPythonInterpreter` managed manually.

Now `py_runmain` takes ownership of its receiver, so Rust will refuse even to compile a program that attempts to call `acquire_gil` after `py_runmain`.

Because such an error is now impossible, `acquire_gil` has become infallible. I removed the `Result` wrapping of the `Python` return type to reflect this.

These are breaking changes, but `py_runmain`'s taking ownership of `MainPythonInterpreter` is safer, taking advantage of the benefits of Rust that make dealing with its borrow checker worthwhile. And if `acquire_gil` continued
to return a `Result`, it would be confusing for beginners, and the constant `.unwrap()`ing would be un-ergonomic for maintainers.