### PR TITLE
Use absolute exe path in pyembed.OxidizedPythonInterpreterConfig

### DIFF
--- a/pyembed/Cargo.toml
+++ b/pyembed/Cargo.toml
@@ -17,6 +17,7 @@ links = "pythonXY"
 # Update documentation in lib.rs when new dependencies are added.
 anyhow = "1.0"
 cpython = "0.5.2"
+dunce = "1.0.1"
 jemalloc-sys = { version = "0.3", optional = true }
 lazy_static = "1.4"
 libc = "0.2"

--- a/pyembed/deny.toml
+++ b/pyembed/deny.toml
@@ -5,6 +5,7 @@
 unlicensed = "deny"
 allow = [
     "0BSD",
+    "CC0-1.0",
     "MIT",
     "MPL-2.0",
     "Python-2.0",

--- a/pyembed/src/config.rs
+++ b/pyembed/src/config.rs
@@ -232,8 +232,10 @@ impl<'a> OxidizedPythonInterpreterConfig<'a> {
         let exe = if let Some(exe) = self.exe {
             exe
         } else {
-            std::env::current_exe()
-                .map_err(|_| NewInterpreterError::Simple("could not obtain current executable"))?
+            std::fs::canonicalize(
+                std::env::current_exe()
+                    .map_err(|_| NewInterpreterError::Simple("could not obtain current executable"))?
+            ).map_err(|_| NewInterpreterError::Simple("could not obtain current executable path"))?
         };
 
         let origin = if let Some(origin) = self.origin {

--- a/pyembed/src/config.rs
+++ b/pyembed/src/config.rs
@@ -232,7 +232,7 @@ impl<'a> OxidizedPythonInterpreterConfig<'a> {
         let exe = if let Some(exe) = self.exe {
             exe
         } else {
-            std::fs::canonicalize(
+            dunce::canonicalize(
                 std::env::current_exe()
                     .map_err(|_| NewInterpreterError::Simple("could not obtain current executable"))?
             ).map_err(|_| NewInterpreterError::Simple("could not obtain current executable path"))?


### PR DESCRIPTION
SSIA

This allows to keep correct paths for filesystem importer in case of symbolic linking built executables on all operative systems, as `std::env::current_exe` [might not return consistent results](https://doc.rust-lang.org/std/env/fn.current_exe.html#platform-specific-behavior).