### PR TITLE
Use of Snmalloc C api for python

### DIFF
--- a/pyembed/src/pyalloc.rs
+++ b/pyembed/src/pyalloc.rs
@@ -242,7 +242,7 @@ extern "C" fn mimalloc_malloc(_ctx: *mut c_void, size: size_t) -> *mut c_void {
 }
 
 #[cfg(feature = "snmalloc-sys")]
-extern "C" fn snmalloc_malloc(ctx: *mut c_void, size: size_t) -> *mut c_void {
+extern "C" fn snmalloc_malloc(_ctx: *mut c_void, size: size_t) -> *mut c_void {
     let size = match size {
         0 => 1,
         val => val,
@@ -288,7 +288,7 @@ extern "C" fn mimalloc_calloc(_ctx: *mut c_void, nelem: size_t, elsize: size_t) 
 }
 
 #[cfg(feature = "snmalloc-sys")]
-extern "C" fn snmalloc_calloc(ctx: *mut c_void, nelem: size_t, elsize: size_t) -> *mut c_void {
+extern "C" fn snmalloc_calloc(_ctx: *mut c_void, nelem: size_t, elsize: size_t) -> *mut c_void {
     let size = match nelem * elsize {
         0 => 1,
         val => val,
@@ -410,7 +410,7 @@ extern "C" fn mimalloc_free(_ctx: *mut c_void, ptr: *mut c_void) {
 }
 
 #[cfg(feature = "snmalloc-sys")]
-extern "C" fn snmalloc_free(ctx: *mut c_void, ptr: *mut c_void) {
+extern "C" fn snmalloc_free(_ctx: *mut c_void, ptr: *mut c_void) {
     if ptr.is_null() {
         return;
     }
@@ -455,7 +455,7 @@ extern "C" fn mimalloc_arena_free(_ctx: *mut c_void, ptr: *mut c_void, _size: si
 }
 
 #[cfg(feature = "snmalloc-sys")]
-extern "C" fn snmalloc_arena_free(ctx: *mut c_void, ptr: *mut c_void, size: size_t) {
+extern "C" fn snmalloc_arena_free(_ctx: *mut c_void, ptr: *mut c_void, _size: size_t) {
     if ptr.is_null() {
         return;
     }

--- a/pyembed/src/pyalloc.rs
+++ b/pyembed/src/pyalloc.rs
@@ -102,9 +102,6 @@ use {
 
 const MIN_ALIGN: usize = 16;
 
-#[cfg(feature = "snmalloc-sys")]
-const SNMALLOC_ALIGNMENT: usize = 8;
-
 /// Tracks allocations from an allocator.
 ///
 /// Some allocators need to pass the original allocation size and alignment
@@ -251,14 +248,7 @@ extern "C" fn snmalloc_malloc(ctx: *mut c_void, size: size_t) -> *mut c_void {
         val => val,
     };
 
-    let mut tracker = AllocationTracker::from_owned_ptr(ctx);
-
-    let layout = unsafe { alloc::Layout::from_size_align_unchecked(size, SNMALLOC_ALIGNMENT) };
-    let res = unsafe { snmalloc_sys::rust_alloc(SNMALLOC_ALIGNMENT, size) as *mut _ };
-
-    tracker.insert_allocation(res, layout);
-
-    res
+    unsafe { snmalloc_sys::sn_malloc(size) as *mut _ }
 }
 
 extern "C" fn rust_calloc(ctx: *mut c_void, nelem: size_t, elsize: size_t) -> *mut c_void {
@@ -304,23 +294,7 @@ extern "C" fn snmalloc_calloc(ctx: *mut c_void, nelem: size_t, elsize: size_t) -
         val => val,
     };
 
-    let mut tracker = AllocationTracker::from_owned_ptr(ctx);
-
-    let layout = unsafe { alloc::Layout::from_size_align_unchecked(size, SNMALLOC_ALIGNMENT) };
-
-    let ptr: *mut c_void = unsafe { snmalloc_sys::rust_alloc(SNMALLOC_ALIGNMENT, size) } as *mut _;
-    if ptr.is_null() {
-        return ptr;
-    }
-
-    // TODO should we use write_volatile() + memory fence to be sure?
-    unsafe {
-        std::ptr::write_bytes(ptr, 0, size);
-    }
-
-    tracker.insert_allocation(ptr, layout);
-
-    ptr
+    unsafe { snmalloc_sys::sn_calloc(nelem, size) as *mut _ }
 }
 
 extern "C" fn rust_realloc(ctx: *mut c_void, ptr: *mut c_void, new_size: size_t) -> *mut c_void {
@@ -396,24 +370,7 @@ extern "C" fn snmalloc_realloc(
         val => val,
     };
 
-    let mut tracker = AllocationTracker::from_owned_ptr(ctx);
-
-    let layout = unsafe { alloc::Layout::from_size_align_unchecked(new_size, SNMALLOC_ALIGNMENT) };
-
-    let old_layout = tracker.remove_allocation(ptr);
-
-    let res = unsafe {
-        snmalloc_sys::rust_realloc(
-            ptr as *mut _,
-            SNMALLOC_ALIGNMENT,
-            old_layout.size(),
-            new_size,
-        ) as *mut _
-    };
-
-    tracker.insert_allocation(res, layout);
-
-    res
+    unsafe { snmalloc_sys::sn_realloc(ptr as *mut _, new_size) as *mut _ }
 }
 
 extern "C" fn rust_free(ctx: *mut c_void, ptr: *mut c_void) {
@@ -458,17 +415,7 @@ extern "C" fn snmalloc_free(ctx: *mut c_void, ptr: *mut c_void) {
         return;
     }
 
-    let mut tracker = AllocationTracker::from_owned_ptr(ctx);
-
-    let layout = tracker
-        .get_allocation(ptr)
-        .unwrap_or_else(|| panic!("could not find allocated memory record: {:?}", ptr));
-
-    unsafe {
-        snmalloc_sys::rust_dealloc(ptr as *mut _, SNMALLOC_ALIGNMENT, layout.size());
-    }
-
-    tracker.remove_allocation(ptr);
+    unsafe { snmalloc_sys::sn_free(ptr as *mut _) }
 }
 
 extern "C" fn rust_arena_free(ctx: *mut c_void, ptr: *mut c_void, _size: size_t) {
@@ -513,13 +460,7 @@ extern "C" fn snmalloc_arena_free(ctx: *mut c_void, ptr: *mut c_void, size: size
         return;
     }
 
-    let mut tracker = AllocationTracker::from_owned_ptr(ctx);
-
-    unsafe {
-        snmalloc_sys::rust_dealloc(ptr as *mut _, SNMALLOC_ALIGNMENT, size);
-    }
-
-    tracker.remove_allocation(ptr);
+    unsafe { snmalloc_sys::sn_free(ptr as *mut _) }
 }
 
 /// Represents a `PyMemAllocatorEx` that can be installed as a memory allocator.
@@ -640,25 +581,22 @@ impl PythonMemoryAllocator {
     /// Construct a new instance using snmalloc.
     #[cfg(feature = "snmalloc-sys")]
     pub fn snmalloc() -> Self {
-        let state = Box::into_raw(AllocationTracker::new());
-
         Self {
             backend: MemoryAllocatorBackend::Snmalloc,
-            instance: AllocatorInstance::Tracking(TrackingAllocator {
-                allocator: pyffi::PyMemAllocatorEx {
-                    ctx: state as *mut c_void,
+            instance: AllocatorInstance::Simple(
+                pyffi::PyMemAllocatorEx {
+                    ctx: std::ptr::null_mut(),
                     malloc: Some(snmalloc_malloc),
                     calloc: Some(snmalloc_calloc),
                     realloc: Some(snmalloc_realloc),
                     free: Some(snmalloc_free),
                 },
-                arena: pyffi::PyObjectArenaAllocator {
-                    ctx: state as *mut c_void,
+                pyffi::PyObjectArenaAllocator {
+                    ctx: std::ptr::null_mut(),
                     alloc: Some(snmalloc_malloc),
                     free: Some(snmalloc_arena_free),
                 },
-                _state: unsafe { Box::from_raw(state) },
-            }),
+            ),
         }
     }
 


### PR DESCRIPTION
This is with the addition of snmalloc C API access to rust allowing python to integrate directly. pull request has been merged to snmalloc for these additions https://github.com/microsoft/snmalloc/pull/290 to rust.cc and to  to snmalloc-rs https://github.com/SchrodingerZhu/snmalloc-rs/pull/115.