### PR TITLE
cryptographic-message-syntax: Add support for parsing signatures that use SHA512 digests

### DIFF
--- a/tugger-apple-codesign/src/verify.rs
+++ b/tugger-apple-codesign/src/verify.rs
@@ -357,10 +357,12 @@ fn verify_cms_signature(data: &[u8], context: VerificationContext) -> Vec<Verifi
     for signer in signed_data.signers() {
         match signer.digest_algorithm() {
             DigestAlgorithm::Sha256 => {}
+            DigestAlgorithm::Sha512 => {}
         }
 
         match signer.signature_algorithm() {
             SignatureAlgorithm::Sha256Rsa
+            | SignatureAlgorithm::Sha512Rsa
             | SignatureAlgorithm::EcdsaSha256
             | SignatureAlgorithm::Ed25519 => {}
             // RsaesPkcsV15 appears to be in widespread use. Should we still notify?


### PR DESCRIPTION
This commit adds support for parsing CMS signatures that use SHA512 digests. Ubuntu's kernel module signatures, for example, use SHA512.

Example signature I used for testing: [ubuntu.ko.sig.gz](https://github.com/indygreg/PyOxidizer/files/6372977/ubuntu.ko.sig.gz)

Sample signature's details from openssl:

<details>
<summary><code>openssl cms -inform der -in output.ko.sig -cmsout -noout -print</code></summary>

```
CMS_ContentInfo: 
  contentType: pkcs7-signedData (1.2.840.113549.1.7.2)
  d.signedData: 
    version: 1
    digestAlgorithms:
        algorithm: sha512 (2.16.840.1.101.3.4.2.3)
        parameter: <ABSENT>
    encapContentInfo: 
      eContentType: pkcs7-data (1.2.840.113549.1.7.1)
      eContent: <ABSENT>
    certificates:
      <ABSENT>
    crls:
      <ABSENT>
    signerInfos:
        version: 1
        d.issuerAndSerialNumber: 
          issuer: CN=Build time autogenerated kernel key
          serialNumber: 0x7825C20A4E41607B4A4E194A8F0C8AEE314D54BF
        digestAlgorithm: 
          algorithm: sha512 (2.16.840.1.101.3.4.2.3)
          parameter: <ABSENT>
        signedAttrs:
          <ABSENT>
        signatureAlgorithm: 
          algorithm: rsaEncryption (1.2.840.113549.1.1.1)
          parameter: NULL
        signature: 
          0000 - 7d 6d 94 f8 57 06 54 4f-f5 a4 76 51 dd 61 83   }m..W.TO..vQ.a.
          000f - 63 3b 90 52 c3 d2 02 cb-aa b1 a0 ca 1f da dc   c;.R...........
          001e - 37 b4 9c 64 01 23 35 12-2a b0 22 44 66 1b e7   7..d.#5.*."Df..
          002d - 7a f5 91 b3 7d e2 af 0b-60 8a ab 43 ec 15 c1   z...}...`..C...
          003c - f0 7d e2 7a d6 fd b5 24-ef 4e 52 2a d6 92 53   .}.z...$.NR*..S
          004b - 7a ba e8 f4 27 39 29 2b-18 71 96 e5 31 0a 10   z...'9)+.q..1..
          005a - ed a2 f6 b6 8b 79 23 02-47 2f b3 48 9c 96 2f   .....y#.G/.H../
          0069 - e9 bf 22 d5 87 2d bb 07-80 63 4e a4 02 68 13   .."..-...cN..h.
          0078 - 97 bd 63 e9 82 e6 8e 30-ae c8 74 e4 5b 38 73   ..c....0..t.[8s
          0087 - c8 a5 2d b9 fb ea 25 18-dd d0 2a ba ae b6 cd   ..-...%...*....
          0096 - dc 1e 98 b9 54 7b c0 cc-45 98 41 41 a4 1a 27   ....T{..E.AA..'
          00a5 - e4 4d 27 01 c1 3d 51 64-56 80 04 2a fe 5f 52   .M'..=QdV..*._R
          00b4 - b0 75 a4 b1 d3 2f a6 85-4d eb 52 37 4a 4b a3   .u.../..M.R7JK.
          00c3 - fe 52 d9 23 d0 f8 d6 85-dc ab b6 51 d8 2f 2d   .R.#.......Q./-
          00d2 - 1b 09 ad c6 c5 93 28 e8-80 14 7c 2e 36 ae 8f   ......(...|.6..
          00e1 - de a9 be 11 39 ab 07 72-9f ce 27 97 69 a6 d9   ....9..r..'.i..
          00f0 - 6a a0 50 d6 ba f0 16 b9-24 6b 64 2c d1 ac a0   j.P.....$kd,...
          00ff - 12 eb 1e 17 d6 5c a8 4b-8f 08 55 af 9a d6 eb   .....\.K..U....
          010e - c6 76 80 15 4c a2 d8 19-b2 ed 6f 00 32 90 b4   .v..L.....o.2..
          011d - 6c c1 5e a4 ec 2d 09 a3-ff 5c 2b 4f 00 86 c6   l.^..-...\+O...
          012c - 4b 1a c1 32 96 2c ee d4-7b ce 56 b5 5d 92 a1   K..2.,..{.V.]..
          013b - 9e f0 b3 0e 6c fd 3f 55-b1 00 16 a2 81 fb 9e   ....l.?U.......
          014a - 49 e9 99 0f e3 f3 82 b1-b4 df 13 5d 8f 2c e2   I..........].,.
          0159 - 0b d5 8a 7e 4d 4b 79 40-da 72 ba 96 f6 84 62   ...~MKy@.r....b
          0168 - 53 4d 8f 79 2d 83 5c 16-bb 9d a2 2c 73 68 76   SM.y-.\....,shv
          0177 - 1c 7a ca b9 c2 cc b8 96-91 81 ec 12 28 e4 64   .z..........(.d
          0186 - a2 63 c5 fd 59 db ab a6-03 2b 07 7e 57 bc a5   .c..Y....+.~W..
          0195 - 18 7e 98 78 c9 da eb c5-f4 65 66 04 6f 46 eb   .~.x.....ef.oF.
          01a4 - 2b a0 1b 2c 60 10 f5 db-c4 ad 42 e3 d1 08 68   +..,`.....B...h
          01b3 - fd f2 50 d6 ba 32 43 f3-c6 f0 de b5 d6 29 9e   ..P..2C......).
          01c2 - 7d bd f3 30 82 2f 38 63-1e e4 8d fd 15 61 00   }..0./8c.....a.
          01d1 - 0f 6c ff 74 fa eb 0d 8d-33 fb c9 4a 0e 5c da   .l.t....3..J.\.
          01e0 - ef 66 f0 c4 81 09 12 0d-6f 80 25 f6 e4 07 f5   .f......o.%....
          01ef - c8 c1 22 d9 34 b1 9c 4f-67 c2 08 6e 78 47 a2   ..".4..Og..nxG.
          01fe - 2c 1e                                          ,.
        unsignedAttrs:
          <ABSENT>
```
</details>

<details>
<summary><code>openssl asn1parse -i -in ubuntu.ko.sig -inform der</code></summary>

```
    0:d=0  hl=4 l= 677 cons: SEQUENCE          
    4:d=1  hl=2 l=   9 prim:  OBJECT            :pkcs7-signedData
   15:d=1  hl=4 l= 662 cons:  cont [ 0 ]        
   19:d=2  hl=4 l= 658 cons:   SEQUENCE          
   23:d=3  hl=2 l=   1 prim:    INTEGER           :01
   26:d=3  hl=2 l=  13 cons:    SET               
   28:d=4  hl=2 l=  11 cons:     SEQUENCE          
   30:d=5  hl=2 l=   9 prim:      OBJECT            :sha512
   41:d=3  hl=2 l=  11 cons:    SEQUENCE          
   43:d=4  hl=2 l=   9 prim:     OBJECT            :pkcs7-data
   54:d=3  hl=4 l= 623 cons:    SET               
   58:d=4  hl=4 l= 619 cons:     SEQUENCE          
   62:d=5  hl=2 l=   1 prim:      INTEGER           :01
   65:d=5  hl=2 l=  70 cons:      SEQUENCE          
   67:d=6  hl=2 l=  46 cons:       SEQUENCE          
   69:d=7  hl=2 l=  44 cons:        SET               
   71:d=8  hl=2 l=  42 cons:         SEQUENCE          
   73:d=9  hl=2 l=   3 prim:          OBJECT            :commonName
   78:d=9  hl=2 l=  35 prim:          UTF8STRING        :Build time autogenerated kernel key
  115:d=6  hl=2 l=  20 prim:       INTEGER           :7825C20A4E41607B4A4E194A8F0C8AEE314D54BF
  137:d=5  hl=2 l=  11 cons:      SEQUENCE          
  139:d=6  hl=2 l=   9 prim:       OBJECT            :sha512
  150:d=5  hl=2 l=  13 cons:      SEQUENCE          
  152:d=6  hl=2 l=   9 prim:       OBJECT            :rsaEncryption
  163:d=6  hl=2 l=   0 prim:       NULL              
  165:d=5  hl=4 l= 512 prim:      OCTET STRING      [HEX DUMP]:7D6D94F85706544FF5A47651DD6183633B9052C3D202CBAAB1A0CA1FDADC37B49C64012335122AB02244661BE77AF591B37DE2AF0B608AAB43EC15C1F07DE27AD6FDB524EF4E522AD692537ABAE8F42739292B187196E5310A10EDA2F6B68B792302472FB3489C962FE9BF22D5872DBB0780634EA402681397BD63E982E68E30AEC874E45B3873C8A52DB9FBEA2518DDD02ABAAEB6CDDC1E98B9547BC0CC45984141A41A27E44D2701C13D51645680042AFE5F52B075A4B1D32FA6854DEB52374A4BA3FE52D923D0F8D685DCABB651D82F2D1B09ADC6C59328E880147C2E36AE8FDEA9BE1139AB07729FCE279769A6D96AA050D6BAF016B9246B642CD1ACA012EB1E17D65CA84B8F0855AF9AD6EBC67680154CA2D819B2ED6F003290B46CC15EA4EC2D09A3FF5C2B4F0086C64B1AC132962CEED47BCE56B55D92A19EF0B30E6CFD3F55B10016A281FB9E49E9990FE3F382B1B4DF135D8F2CE20BD58A7E4D4B7940DA72BA96F68462534D8F792D835C16BB9DA22C7368761C7ACAB9C2CCB8969181EC1228E464A263C5FD59DBABA6032B077E57BCA5187E9878C9DAEBC5F46566046F46EB2BA01B2C6010F5DBC4AD42E3D10868FDF250D6BA3243F3C6F0DEB5D6299E7DBDF330822F38631EE48DFD1561000F6CFF74FAEB0D8D33FBC94A0E5CDAEF66F0C48109120D6F8025F6E407F5C8C122D934B19C4F67C2086E7847A22C1E
```
</details>