### PR TITLE
`spdx=0.4.1` dependency increases MSRV to 1.52

### DIFF
--- a/python-packaging/Cargo.toml
+++ b/python-packaging/Cargo.toml
@@ -20,7 +20,7 @@ mailparse = "0.13"
 once_cell = "1.7"
 regex = "1"
 sha2 = { version = "0.9", optional = true }
-spdx = "0.4"
+spdx = "= 0.4.0"
 time = { version = "0.1", optional = true }
 walkdir = "2"
 zip = { version = "0.5", optional = true }

--- a/tugger-licensing-net/Cargo.toml
+++ b/tugger-licensing-net/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
-spdx = "0.4"
+spdx = "= 0.4.0"
 url = "2.2"
 
 [dependencies.tugger-licensing]

--- a/tugger-licensing/Cargo.toml
+++ b/tugger-licensing/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"
-spdx = "0.4"
+spdx = "= 0.4.0"


### PR DESCRIPTION
Running `cargo install pyoxidizer` with Rust 1.50.0 on Windows 10 failed, complaining about use of unstable feature `str_split_once`.

The usage occurs in `spdx::lexer::find_document_and_license_ref`. The change was introduced in `spdx@0.4.1` as part of removing dependence on `regex`/`lazy_static`. That's awesome for compilation-speed/binary-size, but now all depending crates transitively depend on Rust >=1.52, the version which stabilized `str::split_once`. This isn't a big deal for me personally, because I don't have a reason to use an older toolchain (I just hadn't upgraded for a bit). But, since this project's MSRV is 1.46, I thought this might become an issue for someone else.

`python-packaging`, `tugger-licensing`, and `tugger-licensing-net` all depend on `spdx = "0.4"`. Cloning the repo and building from source succeeds; the Cargo.lock pins `spdx=0.4.0`. However, `cargo install --path pyoxidizer` fails just like `cargo install pyoxidizer`. Apparently, `cargo install` doesn't respect `Cargo.lock` unless you use `--locked`.

Constraining `spdx = "= 0.4.0"` fixes this, at the cost of shackling users with Rust >=1.52 to the old implementation. On the other hand, that may be desirable for consistency between MSRV up to current version.

Alternatively, the documentation could add a suggestion to use `cargo install --locked` for older toolchains.