### PR TITLE
make apple crate config optional on windows

### DIFF
--- a/apple-bundle/Cargo.toml
+++ b/apple-bundle/Cargo.toml
@@ -10,11 +10,11 @@ homepage = "https://github.com/indygreg/PyOxidizer"
 repository = "https://github.com/indygreg/PyOxidizer.git"
 readme = "README.md"
 
-[dependencies]
+[target.'cfg(target_vender="apple")'.dependencies]
 anyhow = "1.0"
 plist = "1.2"
 walkdir = "2.3"
 
-[dependencies.tugger-file-manifest]
+[target.'cfg(target_vender="apple")'.dependencies.tugger-file-manifest]
 version = "0.5.0-pre"
 path = "../tugger-file-manifest"

--- a/pyoxidizer/Cargo.toml
+++ b/pyoxidizer/Cargo.toml
@@ -73,7 +73,7 @@ path = "../python-packed-resources"
 version = "0.5.0-pre"
 path = "../starlark-dialect-build-targets"
 
-[dependencies.tugger-apple]
+[target.'cfg(target_vendor="apple")'.dependencies.tugger-apple]
 version = "0.4.0-pre"
 path = "../tugger-apple"
 
@@ -101,7 +101,7 @@ path = "../tugger-licensing"
 version = "0.4.0-pre"
 path = "../tugger-rust-toolchain"
 
-[dependencies.tugger-windows]
+[target.'cfg(target_os="windows")'.dependencies.tugger-windows]
 version = "0.6.0-pre"
 path = "../tugger-windows"
 

--- a/pyoxidizer/src/environment.rs
+++ b/pyoxidizer/src/environment.rs
@@ -16,9 +16,12 @@ use {
         path::{Path, PathBuf},
         sync::{Arc, RwLock},
     },
-    tugger_apple::{find_command_line_tools_sdks, find_default_developer_sdks, AppleSdk},
     tugger_rust_toolchain::install_rust_toolchain,
 };
+
+#[cfg(target_os = "macos")]
+use tugger_apple::{find_command_line_tools_sdks, find_default_developer_sdks, AppleSdk};
+
 
 /// Version string of PyOxidizer's crate from its Cargo.toml.
 const PYOXIDIZER_CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -426,6 +429,7 @@ impl Environment {
     }
 
     /// Attempt to resolve an appropriate Apple SDK to use given settings.
+    #[cfg(target_os = "macos")]
     pub fn resolve_apple_sdk(
         &self,
         logger: &slog::Logger,
@@ -486,6 +490,7 @@ pub struct RustEnvironment {
 /// Given an Apple `platform`, locate an Apple SDK that is of least
 /// `minimum_version` and supports targeting `deployment_target`, which is likely
 /// an OS version string.
+#[cfg(target_os = "macos")]
 pub fn resolve_apple_sdk(
     logger: &slog::Logger,
     platform: &str,

--- a/pyoxidizer/src/project_building.rs
+++ b/pyoxidizer/src/project_building.rs
@@ -161,6 +161,7 @@ impl BuildEnvironment {
         // Here, we validate that the local SDK being used is >= the version used
         // by the Python distribution.
         // TODO validate minimum Clang/linker version as well.
+        #[cfg(target_os = "macos")]
         if target_triple.contains("-apple-") {
             let sdk_info = apple_sdk_info.ok_or_else(|| {
                 anyhow!("targeting Apple platform but Apple SDK info not available")

--- a/pyoxidizer/src/py_packaging/libpython.rs
+++ b/pyoxidizer/src/py_packaging/libpython.rs
@@ -120,6 +120,7 @@ pub fn link_libpython(
     // between it and what we want. For example, if we're building for aarch64 but the default
     // SDK is a 10.15 SDK that doesn't support ARM. We attempt to mitigate this by resolving
     // a compatible Apple SDK and pointing the compiler invocation at it via compiler flags.
+    #[cfg(target_os = "macos")]
     if target_triple.contains("-apple-") {
         let sdk_info = apple_sdk_info.ok_or_else(|| {
             anyhow!("Apple SDK info should be defined when targeting Apple platforms")

--- a/text-stub-library/Cargo.toml
+++ b/text-stub-library/Cargo.toml
@@ -20,6 +20,6 @@ rand = "0.8"
 rayon = "1.5"
 walkdir = "2.3"
 
-[dev-dependencies.tugger-apple]
+[target.'cfg(target_vender="apple")'.dev-dependencies.tugger-apple]
 version = "0.4.0-pre"
 path = "../tugger-apple"

--- a/tugger-apple-codesign/Cargo.toml
+++ b/tugger-apple-codesign/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 name = "rcodesign"
 path = "src/main.rs"
 
-[dependencies]
+[target.'cfg(target_vender="apple")'.dependencies]
 anyhow = "1.0"
 base64 = "0.13"
 bcder = "0.6"
@@ -37,7 +37,7 @@ slog-term = "2.8"
 thiserror = "1.0"
 yasna = "0.3"
 
-[dependencies.apple-bundle]
+[target.'cfg(target_vender="apple")'.dependencies.apple-bundle]
 path = "../apple-bundle"
 version = "0.5.0-pre"
 
@@ -45,7 +45,7 @@ version = "0.5.0-pre"
 path = "../cryptographic-message-syntax"
 version = "0.4.0-pre"
 
-[dependencies.tugger-apple]
+[target.'cfg(target_vender="apple")'.dependencies.tugger-apple]
 path = "../tugger-apple"
 version = "0.4.0-pre"
 

--- a/tugger-apple/Cargo.toml
+++ b/tugger-apple/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/indygreg/PyOxidizer"
 repository = "https://github.com/indygreg/PyOxidizer.git"
 readme = "README.md"
 
-[dependencies]
+[target.'cfg(target_vender="apple")'.dependencies]
 anyhow = "1.0"
 duct = "0.13"
 goblin = "0.4"

--- a/tugger-code-signing/Cargo.toml
+++ b/tugger-code-signing/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.2"
 thiserror = "1.0"
 yasna = "0.3"
 
-[dependencies.apple-bundle]
+[target.'cfg(target_vender="apple")'.dependencies.apple-bundle]
 version = "0.5.0-pre"
 path = "../apple-bundle"
 
@@ -29,7 +29,7 @@ path = "../apple-bundle"
 version = "0.4.0-pre"
 path = "../cryptographic-message-syntax"
 
-[dependencies.tugger-apple-codesign]
+[target.'cfg(target_vender="apple")'.dependencies.tugger-apple-codesign]
 version = "0.5.0-pre"
 path = "../tugger-apple-codesign"
 
@@ -37,7 +37,7 @@ path = "../tugger-apple-codesign"
 version = "0.5.0-pre"
 path = "../tugger-file-manifest"
 
-[dependencies.tugger-windows-codesign]
+[target.'cfg(target_os="windows")'.dependencies.tugger-windows-codesign]
 version = "0.4.0-pre"
 path = "../tugger-windows-codesign"
 

--- a/tugger-windows-codesign/Cargo.toml
+++ b/tugger-windows-codesign/Cargo.toml
@@ -23,7 +23,7 @@ yasna = "0.3"
 version = "0.5.0-pre"
 path = "../tugger-common"
 
-[dependencies.tugger-windows]
+[target.'cfg(target_os="windows")'.dependencies.tugger-windows]
 version = "0.6.0-pre"
 path = "../tugger-windows"
 

--- a/tugger/Cargo.toml
+++ b/tugger/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = "3.2"
 time = "0.2"
 walkdir = "2"
 
-[dependencies.apple-bundle]
+[target.'cfg(target_vender="apple")'.dependencies.apple-bundle]
 version = "0.5.0-pre"
 path = "../apple-bundle"
 
@@ -39,7 +39,7 @@ path = "../python-packaging"
 version = "0.5.0-pre"
 path = "../starlark-dialect-build-targets"
 
-[dependencies.tugger-apple]
+[target.'cfg(target_vender="apple")'.dependencies.tugger-apple]
 version = "0.4.0-pre"
 path = "../tugger-apple"
 
@@ -55,7 +55,7 @@ path = "../tugger-common"
 version = "0.6.0-pre"
 path = "../tugger-snapcraft"
 
-[dependencies.tugger-windows]
+[target.'cfg(target_os="windows")'.dependencies.tugger-windows]
 version = "0.6.0-pre"
 path = "../tugger-windows"
 
@@ -71,11 +71,11 @@ path = "../tugger-file-manifest"
 chrono = "0.4"
 tempfile = "3.2"
 
-[dev-dependencies.tugger-apple-codesign]
+[target.'cfg(target_vender="apple")'.dev-dependencies.tugger-apple-codesign]
 version = "0.5.0-pre"
 path = "../tugger-apple-codesign"
 
-[dev-dependencies.tugger-windows-codesign]
+[target.'cfg(target_os="windows")'.dev-dependencies.tugger-windows-codesign]
 version = "0.4.0-pre"
 path = "../tugger-windows-codesign"
 

--- a/tugger/src/starlark/mod.rs
+++ b/tugger/src/starlark/mod.rs
@@ -7,12 +7,13 @@ The `starlark` module and related sub-modules define the
 [Starlark](https://github.com/bazelbuild/starlark) dialect used by
 Tugger.
 */
-
+#[cfg(target_os = "macos")]
 pub mod apple_universal_binary;
 pub mod code_signing;
 pub mod file_content;
 pub mod file_manifest;
 pub mod file_resource;
+#[cfg(target_os = "macos")]
 pub mod macos_application_bundle_builder;
 pub mod python_wheel_builder;
 pub mod snapcraft;
@@ -127,11 +128,13 @@ pub fn register_starlark_dialect(
     env: &mut Environment,
     type_values: &mut TypeValues,
 ) -> Result<(), EnvironmentError> {
+    #[cfg(target_os = "macos")]
     apple_universal_binary::apple_universal_binary_module(env, type_values);
     code_signing::code_signing_module(env, type_values);
     file_content::file_content_module(env, type_values);
     file_manifest::file_manifest_module(env, type_values);
     file_resource::file_resource_module(env, type_values);
+    #[cfg(target_os = "macos")]
     macos_application_bundle_builder::macos_application_bundle_builder_module(env, type_values);
     python_wheel_builder::python_wheel_builder_module(env, type_values);
     snapcraft::snapcraft_module(env, type_values);


### PR DESCRIPTION
I downloaded most recent version of pyoxidizer and have been trying to install but ran into crates for apple potions of code failing on windows, can we please make the apple portion config optional on windows, this is minimum I had to do to work on windows as a start.