### PR TITLE
Fix broken examples

### DIFF
--- a/pyoxidizer/docs/pyoxidizer_packaging_config_file.rst
+++ b/pyoxidizer/docs/pyoxidizer_packaging_config_file.rst
@@ -32,12 +32,13 @@ In this example, we create an executable embedding Python:
 
 .. code-block:: python
 
-    def make_exe(dist):
+    def make_exe():
         dist = default_python_distribution()
 
         return dist.to_python_executable("myapp")
 
     register_target("exe", make_exe)
+    resolve_targets()
 
 :py:meth:`PythonDistribution.to_python_executable` accepts an optional
 :py:class:`PythonPackagingPolicy` instance that influences how the executable
@@ -67,7 +68,7 @@ this instance into the constructed :py:class:`PythonExecutable`:
 
 .. code-block:: python
 
-    def make_exe(dist):
+    def make_exe():
         dist = default_python_distribution()
 
         config = dist.make_python_interpreter_config()
@@ -76,6 +77,7 @@ this instance into the constructed :py:class:`PythonExecutable`:
         return dist.to_python_executable("myapp", config=config)
 
     register_target("exe", make_exe)
+    resolve_targets()
 
 The :py:class:`PythonInterpreterConfig` type exposes a lot of modifiable settings.
 See the :py:class:`API documentation <PythonInterpreterConfig>` for
@@ -147,7 +149,7 @@ instance using
 
 .. code-block:: python
 
-    def make_exe(dist):
+    def make_exe():
         dist = default_python_distribution()
 
         return dist.to_python_executable("myapp")
@@ -164,6 +166,7 @@ instance using
 
     register_target("exe", make_exe)
     register_target("install", make_install, depends=["exe"], default=True)
+    resolve_targets()
 
 We introduce a new ``install`` target and ``make_install()`` function which
 returns a :py:class:`starlark_tugger.FileManifest`. It adds the


### PR DESCRIPTION
They still don't work, but at least they don't work in a more subtle way.

Before:

without `resolve_targets()`:

```
$ pyoxidizer build
error: target exe is not resolved
```

with `resolve_targets()`, but without removing the `dist` arg:

```
$ pyoxidizer build
resolving 1 targets
resolving target exe
error[CF00]: Missing parameter dist for call to <function make_exe from pyoxidizer>(dist)
  --> ./pyoxidizer.bzl:10:1
   |
10 | resolve_targets()
   | ^^^^^^^^^^^^^^^^^ Not enough parameters in function call


error: Missing parameter dist for call to <function make_exe from pyoxidizer>(dist)
```

Now:

```
<lots of build output>
writing executable to /..././build/x86_64-unknown-linux-gnu/debug/exe/myapp
error: error calling build(): Runtime(RuntimeError { code: "PYOXIDIZER_PYTHON_EXECUTABLE", message: "creating /..././build/x86_64-unknown-linux-gnu/debug/exe/myapp\n\nCaused by:\n    No such file or directory (os error 2)", label: "PythonExecutable.build()" })
```

So that's an improvement.

No idea where to go from here but hey. (Tried with both `pipx run` on python 3.9, and `pip install pyoxidizer --user` with 3.7. Broken on both.)