### PR TITLE
python-packaging: honor add_context.include for non-stdlib extensions

### DIFF
--- a/pyoxidizer/docs/pyoxidizer_config_type_python_extension_module.rst
+++ b/pyoxidizer/docs/pyoxidizer_config_type_python_extension_module.rst
@@ -26,3 +26,6 @@
         (various)
 
         See :ref:`config_resource_add_attributes`.
+
+        Note: `add_include` is currently ignored for builtin modules, and can not
+        be used to control their inclusion.

--- a/python-packaging/src/resource_collection.rs
+++ b/python-packaging/src/resource_collection.rs
@@ -1301,10 +1301,10 @@ impl PythonResourceCollector {
         extension_module: &PythonExtensionModule,
         add_context: &PythonResourceAddCollectionContext,
     ) -> Result<Option<LibPythonBuildContext>> {
-        // TODO consult this attribute (it isn't set for built-ins for some reason)
-        //if !add_context.include {
-        //    return Ok(None);
-        // }
+        // TODO: investigate why `include` is always false for stdlib modules
+        if !add_context.include && !extension_module.is_stdlib {
+            return Ok(None);
+        }
 
         // Whether we can load extension modules as standalone shared library files.
         let can_load_standalone = self


### PR DESCRIPTION
The setting was previously indiscriminately ignored, meaning it wasn't
possible to prevent third-party extension modules from being included
in the build.

Related: #405