### PR TITLE
starlark: Add PythonExecutable.write_aggregate_license_text to write aggregated license file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,6 +2514,7 @@ dependencies = [
  "tugger-common",
  "tugger-file-manifest",
  "tugger-licensing",
+ "tugger-licensing-net",
  "tugger-rust-toolchain",
  "tugger-windows",
  "tugger-wix",

--- a/pyoxidizer/Cargo.toml
+++ b/pyoxidizer/Cargo.toml
@@ -100,6 +100,11 @@ path = "../tugger-file-manifest"
 version = "0.5.0-pre"
 path = "../tugger-licensing"
 
+[dependencies.tugger-licensing-net]
+version = "0.6.0-pre"
+path = "../tugger-licensing-net"
+
+
 [dependencies.tugger-rust-toolchain]
 version = "0.5.0-pre"
 path = "../tugger-rust-toolchain"

--- a/pyoxidizer/docs/pyoxidizer_config_type_python_executable.rst
+++ b/pyoxidizer/docs/pyoxidizer_config_type_python_executable.rst
@@ -400,3 +400,8 @@
 
        Upon successful generation of a binary, the produced binary will be assessed
        for code signing with the ``python-executable-creation`` *action*.
+
+    .. py:method:: write_aggregate_license_text(path, preamble = tugger_licensing_net::DEFAULT_LICENSE_PREAMBLE)
+
+        Writes an aggregated license text to `path`. This includes all registered
+        software components, this should be all python modules and rust crates.

--- a/pyoxidizer/src/py_packaging/binary.rs
+++ b/pyoxidizer/src/py_packaging/binary.rs
@@ -34,6 +34,7 @@ use {
     tugger_file_manifest::{File, FileManifest},
     tugger_windows::VcRedistributablePlatform,
 };
+use tugger_licensing::LicensedComponent;
 
 include!("../pyembed-license.rs");
 
@@ -281,6 +282,11 @@ pub trait PythonBinaryBuilder {
     fn iter_resources<'a>(
         &'a self,
     ) -> Box<dyn Iterator<Item = (&'a String, &'a PrePackagedResource)> + 'a>;
+
+    /// Obtain an iterator over all licensed components
+    fn iter_components<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a LicensedComponent> + 'a>;
 
     /// Resolve license metadata from an iterable of `PythonResource` and store that data.
     ///

--- a/pyoxidizer/src/py_packaging/standalone_builder.rs
+++ b/pyoxidizer/src/py_packaging/standalone_builder.rs
@@ -523,6 +523,12 @@ impl PythonBinaryBuilder for StandalonePythonExecutableBuilder {
         Box::new(self.resources_collector.iter_resources())
     }
 
+    fn iter_components<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a LicensedComponent> + 'a> {
+        Box::new(self.resources_collector.iter_licensed_components())
+    }
+
     fn index_package_license_info_from_resources<'a>(
         &mut self,
         resources: &[PythonResource<'a>],

--- a/python-packaging/src/resource_collection.rs
+++ b/python-packaging/src/resource_collection.rs
@@ -845,6 +845,11 @@ impl PythonResourceCollector {
         Ok(())
     }
 
+    /// Get a iterator over the registered licensed software components of this collection
+    pub fn iter_licensed_components(&self) -> impl Iterator<Item = &LicensedComponent> {
+        self.licensed_components.iter_components()
+    }
+
     /// Add Python module source with a specific location.
     pub fn add_python_module_source(
         &mut self,


### PR DESCRIPTION
In audapolis (https://github.com/audapolis/audapolis) we use pyoxidizer to bundle a small webserver with an electron application. We want and need to list the licenses in the software and would like to do that automatically in the build process. The easiest way is to write a license acknowledgement-file during build. This PR implements a starlark method to do so.

This could be a first step to deal with the more general licensing issues when packaging pyoxidizer applications

Example:
```
exe = dist.to_python_executable(
      name="example",

      # If no argument passed, the default `PythonPackagingPolicy` for the
      # distribution is used.
      packaging_policy=policy,

      # If no argument passed, the default `PythonInterpreterConfig` is used.
      config=python_config,
)
exe.write_aggregate_license_text("licenses.md", "This software contains software subject to licenses as described below.")
```
