### PR TITLE
write extra_files when building pyembed artifacts?

### DIFF
--- a/pyoxidizer/src/project_building.rs
+++ b/pyoxidizer/src/project_building.rs
@@ -484,6 +484,10 @@ pub fn build_pyembed_artifacts(
         ))? {
             let p = p?;
 
+            // leave the extra files in the build dir; we do not need them to build the binary
+            if p.file_name() == "extra_files" {
+                continue;
+            }
             let dest_path = artifacts_path.join(p.file_name());
             std::fs::copy(&p.path(), &dest_path).context(format!(
                 "copying {} to {}",

--- a/pyoxidizer/src/py_packaging/binary.rs
+++ b/pyoxidizer/src/py_packaging/binary.rs
@@ -746,6 +746,13 @@ impl<'a> EmbeddedPythonContext<'a> {
         Ok(())
     }
 
+    /// Write extra files like dynamic extension modules to the build folder.
+    pub fn write_extra_files(&self, dest_dir: impl AsRef<Path>) -> Result<()> {
+        self.extra_files
+            .materialize_files(dest_dir.as_ref().join("extra_files"))?;
+        Ok(())
+    }
+
     /// Write out files needed to build a binary against our configuration.
     pub fn write_files(&self, dest_dir: &Path) -> Result<()> {
         self.write_packed_resources(&dest_dir)
@@ -756,6 +763,8 @@ impl<'a> EmbeddedPythonContext<'a> {
             .context("write_interpreter_config_rs()")?;
         self.write_pyo3_config(&dest_dir)
             .context("write_pyo3_config()")?;
+        self.write_extra_files(&dest_dir)
+            .context("write_extra_files()")?;
 
         Ok(())
     }


### PR DESCRIPTION
Intended for discussion, not merging as-is. Based on the 0.17 branch; I'm having issues with the main branch which I'll look into more later.

I'd like to be able customize the icon of the produced .exe file on Windows, and run some custom Rust code before the Python interpreter is loaded. I ran into some problems along the way.

I started by using `pyoxidizer init-rust-project sample`. It tells me:

```
A new Rust binary application has been created in sample

This application can be built by doing the following:

  $ cd sample
  $ pyoxidizer build
  $ pyoxidizer run

[...]
```

So I add a print statement to the top of main.rs, and run build/run. Observations:

- run rebuilds everything again. In the main branch the build line appears to have been removed when creating a normal project, but is still shown when using init-rust-project.
- when run, the print statement doesn't appear.

After digging into the sources, I find that pyoxidizer will unconditionally create an ephemeral project when building, ignoring any sources in the current folder. Looks like this was previously reported in #439. Ok, I'll need to try the direct-with-cargo approach instead.

```
% zstdcat /Users/dae/Library/Caches/pyoxidizer/python_distributions/cpython-3.9.6-x86_64-apple-darwin-pgo-20210724T1424.tar.zst | tar xf -
% cd sample && CARGO_TARGET_DIR=target PYOXIDIZER_EXECUTABLE=$HOME/.cargo/bin/pyoxidizer PYTHON_SYS_EXECUTABLE=$HOME/python/install/bin/python3.9 PYOXIDIZER_CONFIG=$(pwd)/pyoxidizer.bzl cargo build --features cpython-link-unresolved-static,allocator-jemalloc
[...]
% ./target/debug/sample
[src/main.rs:37] "test" = "test"
```

Ok, that's promising. Now let's add an extension module into the equation:

```
    policy.resources_location_fallback = "filesystem-relative:prefix"
    python_config.run_command = "import google.protobuf.internal._api_implementation"
    exe.add_python_resources(exe.pip_download(["protobuf"]))
``` 

I rebuild and try again:

```
dae@dip:~/sample% ./target/debug/sample
[src/main.rs:37] "test" = "test"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: dlopen(/Users/dae/sample/target/debug/prefix/google/protobuf/internal/_api_implementation.cpython-39-darwin.so, 2): image not found
zsh: exit 1     ./target/debug/sample
dae@dip:~/sample% find . -name _api_implementation.cpython-39-darwin.so
dae@dip:~/sample%
```

Hmm, it seems extra_files are nowhere to be found. Back to digging through the source code. It looks like to_embedded_resources() ignores extra_files - they only seem to handled when
building an executable.

With the patch in this PR, I am able to successfully change the icon by adding it to the resources file. But I presume there are other cases where the extra_files should not be included. Which leads me to a few questions:

- Is there a better way to modify the default Rust/resources that I've missed?
- If not, would there be any interest in a change like this? Presumably it would need to be
gated by an env var?