### PR TITLE
pyoxidizer: allow specifying an existing project crate

### DIFF
--- a/pyoxidizer/src/project_building.rs
+++ b/pyoxidizer/src/project_building.rs
@@ -368,7 +368,8 @@ pub fn build_executable_with_rust_project<'a>(
     })
 }
 
-/// Build a Python executable using a temporary Rust project.
+/// Build a Python executable using a temporary Rust project, or
+/// the one specified by the PYOXIDIZER_CRATE_FOLDER env var.
 ///
 /// Returns the binary data constituting the built executable.
 pub fn build_python_executable<'a>(
@@ -380,30 +381,43 @@ pub fn build_python_executable<'a>(
     opt_level: &str,
     release: bool,
 ) -> Result<BuiltExecutable<'a>> {
-    let cargo_exe = env
-        .ensure_rust_toolchain(logger, Some(target_triple))
-        .context("resolving Rust toolchain")?
-        .cargo_exe;
+    let temp_dir: tempfile::TempDir;
+    let project_path: PathBuf;
 
-    let temp_dir = tempfile::Builder::new()
-        .prefix("pyoxidizer")
-        .tempdir()
-        .context("creating temp directory")?;
+    // Existing Rust project provided?
+    let root = if let Ok(folder) = std::env::var("PYOXIDIZER_CRATE_FOLDER") {
+        project_path = PathBuf::from(folder);
+        &project_path
+    } else {
+        // No existing project, we'll need to create a temporary one.
+        let cargo_exe = env
+            .ensure_rust_toolchain(logger, Some(target_triple))
+            .context("resolving Rust toolchain")?
+            .cargo_exe;
 
-    // Directory needs to have name of project.
-    let project_path = temp_dir.path().join(bin_name);
-    let build_path = temp_dir.path().join("build");
-    let artifacts_path = temp_dir.path().join("artifacts");
+        temp_dir = tempfile::Builder::new()
+            .prefix("pyoxidizer")
+            .tempdir()
+            .context("creating temp directory")?;
 
-    initialize_project(
-        &env.pyoxidizer_source,
-        &project_path,
-        &cargo_exe,
-        None,
-        &[],
-        exe.windows_subsystem(),
-    )
-    .context("initializing project")?;
+        // Directory needs to have name of project.
+        project_path = temp_dir.path().join(bin_name);
+
+        initialize_project(
+            &env.pyoxidizer_source,
+            &project_path,
+            &cargo_exe,
+            None,
+            &[],
+            exe.windows_subsystem(),
+        )
+        .context("initializing project")?;
+
+        temp_dir.path()
+    };
+
+    let build_path = root.join("build");
+    let artifacts_path = root.join("artifacts");
 
     let mut build = build_executable_with_rust_project(
         env,


### PR DESCRIPTION
While building directly with cargo is possible (#467), a lot of the convenience that pyoxidizer provides is lost - you need to construct rather long command lines, and manually bundle files up separately (#466). What if instead of an all-or-nothing approach, pyoxidizer provided limited support for building from an existing Rust crate? 

With this PR, the user can build a project created with init-rust-project with a single short command line:

```
$ PYOXIDIZER_CRATE_FOLDER=$(pwd) pyoxidizer build
```

It also happens to be somewhat faster, as crates like jemalloc don't get recompiled each time.

It would come with caveats:
- The user would be responsible for ensuring their crate sources are appropriate for the pyoxidizer version they are invoking
- It may not work with more elaborate embedding use cases - but then, the user is still free to drop back to raw cargo.
- I didn't encounter it in testing, but perhaps there might be cases where a stale build product could require the user to manually clear out their build folder?

What do you think?



