### PR TITLE
pyembed: GIL should be acquired later in the initialization sequence after checking the return value of _Py_InitializeMain()

### DIFF
--- a/pyembed/src/interpreter.rs
+++ b/pyembed/src/interpreter.rs
@@ -190,16 +190,15 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
         // importlib. And if the custom importlib bytecode was registered above,
         // our extension module will get imported and initialized.
         let status = unsafe { pyffi::_Py_InitializeMain() };
-
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-
         if unsafe { pyffi::PyStatus_Exception(status) } != 0 {
             return Err(NewInterpreterError::new_from_pystatus(
                 &status,
                 "initializing Python main",
             ));
         }
+
+        let gil = Python::acquire_gil();
+        let py = gil.python();
 
         let sys_module = py
             .import("sys")


### PR DESCRIPTION
The current initialization sequence in `MainPythonInterpreter::init()` tries to acquire the GIL before checking the return value of `_Py_InitializeMain()`, leading to an assertion failure if `_Py_InitializeMain()` fails (which can happen when building a project with `include_distribution_sources = False`, as outlined in #312 ). This PR moves the result check before the `acquite_gil()` call, which provides a more meaningful error message instead of an assertion failure:

`error instantiating embedded Python interpreter: during initializing Python main: init_fs_encoding: failed to get the Python codec of the filesystem encoding`

Note that this error message was present in PyOxidizer 0.17 and before; it changed to an assertion failure somewhere in newer versions. This PR simply restores the original error message.