### PR TITLE
support ARM Linux builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -85,6 +85,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 

--- a/pyembed/.cargo/config
+++ b/pyembed/.cargo/config
@@ -12,6 +12,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 

--- a/pyembed/src/conversion.rs
+++ b/pyembed/src/conversion.rs
@@ -7,6 +7,7 @@
 use pyo3::{ffi as pyffi, prelude::*};
 
 use std::ffi::OsString;
+use std::os::raw::c_char;
 
 #[cfg(target_family = "unix")]
 use std::os::unix::ffi::OsStrExt;
@@ -18,7 +19,7 @@ use std::os::windows::prelude::OsStrExt;
 pub fn osstring_to_bytes(py: Python, s: OsString) -> &PyAny {
     let b = s.as_bytes();
     unsafe {
-        let o = pyffi::PyBytes_FromStringAndSize(b.as_ptr() as *const i8, b.len() as isize);
+        let o = pyffi::PyBytes_FromStringAndSize(b.as_ptr() as *const c_char, b.len() as isize);
         PyObject::from_owned_ptr(py, o).into_ref(py)
     }
 }
@@ -27,7 +28,7 @@ pub fn osstring_to_bytes(py: Python, s: OsString) -> &PyAny {
 pub fn osstring_to_bytes(py: Python, s: OsString) -> &PyAny {
     let w: Vec<u16> = s.encode_wide().collect();
     unsafe {
-        let o = pyffi::PyBytes_FromStringAndSize(w.as_ptr() as *const i8, w.len() as isize * 2);
+        let o = pyffi::PyBytes_FromStringAndSize(w.as_ptr() as *const c_char, w.len() as isize * 2);
         PyObject::from_owned_ptr(py, o).into_ref(py)
     }
 }

--- a/pyembed/src/interpreter.rs
+++ b/pyembed/src/interpreter.rs
@@ -4,6 +4,7 @@
 
 //! Manage an embedded Python interpreter.
 
+use std::os::raw::c_char;
 use {
     crate::{
         config::{OxidizedPythonInterpreterConfig, ResolvedOxidizedPythonInterpreterConfig},
@@ -272,7 +273,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
             let argvb = b"argvb\0";
 
             let res = args.with_borrowed_ptr(py, |args_ptr| unsafe {
-                pyffi::PySys_SetObject(argvb.as_ptr() as *const i8, args_ptr)
+                pyffi::PySys_SetObject(argvb.as_ptr() as *const c_char, args_ptr)
             });
 
             match res {
@@ -286,7 +287,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
         let oxidized = b"oxidized\0";
 
         let res = true.into_py(py).with_borrowed_ptr(py, |py_true| unsafe {
-            pyffi::PySys_SetObject(oxidized.as_ptr() as *const i8, py_true)
+            pyffi::PySys_SetObject(oxidized.as_ptr() as *const c_char, py_true)
         });
 
         match res {
@@ -298,7 +299,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
             let frozen = b"frozen\0";
 
             match true.into_py(py).with_borrowed_ptr(py, |py_true| unsafe {
-                pyffi::PySys_SetObject(frozen.as_ptr() as *const i8, py_true)
+                pyffi::PySys_SetObject(frozen.as_ptr() as *const c_char, py_true)
             }) {
                 0 => (),
                 _ => return Err(NewInterpreterError::Simple("unable to set sys.frozen")),
@@ -310,7 +311,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
             let value = origin_string.to_object(py);
 
             match value.with_borrowed_ptr(py, |py_value| unsafe {
-                pyffi::PySys_SetObject(meipass.as_ptr() as *const i8, py_value)
+                pyffi::PySys_SetObject(meipass.as_ptr() as *const c_char, py_value)
             }) {
                 0 => (),
                 _ => return Err(NewInterpreterError::Simple("unable to set sys._MEIPASS")),

--- a/pyembed/src/interpreter_config.rs
+++ b/pyembed/src/interpreter_config.rs
@@ -22,7 +22,14 @@ use {
 use std::{ffi::NulError, os::unix::ffi::OsStrExt};
 
 #[allow(non_camel_case_types)]
-#[cfg(target_family = "unix")]
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+type wchar_t = u32;
+
+#[allow(non_camel_case_types)]
+#[cfg(all(
+    target_family = "unix",
+    not(all(target_arch = "aarch64", target_os = "linux"))
+))]
 type wchar_t = i32;
 
 #[cfg(target_family = "windows")]

--- a/pyoxidizer/src/templates/new-cargo-config.hbs
+++ b/pyoxidizer/src/templates/new-cargo-config.hbs
@@ -15,6 +15,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 


### PR DESCRIPTION
fixes errors like the following:

```
error[E0308]: mismatched types
  --> /home/dae/.cargo/git/checkouts/pyoxidizer-dcad61535898da20/200fbd2/pyembed/src/conversion.rs:21:50
   |
21 |         let o = pyffi::PyBytes_FromStringAndSize(b.as_ptr() as *const i8, b.len() as isize);
   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*const i8`

error[E0308]: mismatched types
   --> /home/dae/.cargo/git/checkouts/pyoxidizer-dcad61535898da20/200fbd2/pyembed/src/interpreter_config.rs:494:46
    |
494 |         set_config_string_from_path(&config, &config.home, home, "setting home")?;
    |                                              ^^^^^^^^^^^^ expected `i32`, found `u32`
    |
    = note: expected reference `&*mut i32`
               found reference `&*mut u32`
```

The conditional compilation in interpreter_config.rs is a bit awkward
(aarch64 on macOS uses i32, not u32), but I presumed a dependency on the
libc crate was not desirable for pyembed.