### PR TITLE
- deal with borrowed object ref

### DIFF
--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -152,7 +152,7 @@ fn load_dynamic_library(
     let init_fn: py_init_fn = unsafe { std::mem::transmute(address) };
 
     // Package context is needed for single-phase init.
-    let py_module_initial_handle = unsafe {
+    let py_module = unsafe {
         let old_context = pyffi::_Py_PackageContext;
         pyffi::_Py_PackageContext = name_cstring.as_ptr();
         let py_module = init_fn();
@@ -205,7 +205,7 @@ fn load_dynamic_library(
 
     // Else fall back to single-phase init mechanism.
 
-    let mut module_def = unsafe { pyffi::Py_DECREF(py_module.as_ptr()); // undo the newref call which was needed to suport multiphase initialisation 
+    let mut module_def = unsafe { pyffi::Py_DECREF(py_module.as_ptr()); // undo the newref call which was needed to suport multiphase initialisation
                                   pyffi::PyModule_GetDef(py_module.as_ptr()) };
     if module_def.is_null() {
         return Err(PySystemError::new_err(format!(

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -199,7 +199,7 @@ fn load_dynamic_library(
         return if py_module.is_null() {
             Err(PyErr::fetch(py))
         } else {
-            Ok(unsafe { PyObject::from_owned_ptr(py, py_module) })
+            Ok(unsafe { PyObject::from_borrowed_ptr(py, py_module) })
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -168,9 +168,8 @@ fn load_dynamic_library(
     }
 
     // Cast to owned type to help prevent refcount/memory leaks.
-    let py_module = unsafe { PyObject::from_owned_ptr(py, py_module) };
-
-    if !unsafe { pyffi::PyErr_Occurred().is_null() } {
+    let py_module = unsafe { PyObject::from_borrowed_ptr(py, py_module) };
+pyffi::PyErr_Occurred().is_null() } {
         unsafe {
             pyffi::PyErr_Clear();
         }
@@ -200,7 +199,7 @@ fn load_dynamic_library(
             Err(PyErr::fetch(py))
         } else {
             println!("going to borrow ref.. multiphase");
-            Ok(unsafe { PyObject::from_borrowed_ptr(py, py_module) }) //This is to match description of PEP
+            Ok(unsafe { py_module}) //This is to match description of PEP
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -168,7 +168,7 @@ fn load_dynamic_library(
     }
 
     // Cast to owned type to help prevent refcount/memory leaks.
-    let py_module = unsafe { PyObject::from_borrowed_ptr(py, py_module) };
+    let py_module = unsafe { PyObject::from_owned_ptr(py, py_module) };
 pyffi::PyErr_Occurred().is_null() } {
         unsafe {
             pyffi::PyErr_Clear();
@@ -199,7 +199,8 @@ pyffi::PyErr_Occurred().is_null() } {
             Err(PyErr::fetch(py))
         } else {
             println!("going to borrow ref.. multiphase");
-            Ok(unsafe { py_module}); //This is to match description of PEP
+            pyffi::Py_INCREF(py_module);
+            Ok(unsafe { PyObject::from_owned_ptr(py, py_module) })
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -199,12 +199,13 @@ fn load_dynamic_library(
         return if py_module.is_null() {
             Err(PyErr::fetch(py))
         } else {
+            println!("going to borrow ref.. multiphase");
             Ok(unsafe { PyObject::from_borrowed_ptr(py, py_module) }) //This is to match description of PEP
         };
     }
 
     // Else fall back to single-phase init mechanism.
-
+    println!("no multiphase");
     let mut module_def = unsafe { pyffi::PyModule_GetDef(py_module.as_ptr()) };
     if module_def.is_null() {
         return Err(PySystemError::new_err(format!(

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -200,7 +200,7 @@ fn load_dynamic_library(
             Err(PyErr::fetch(py))
         } else {
             println!("going to incref.. multiphase");
-            Ok(unsafe { PyObject::from_owned_ptr(py, pyffi::_Py_NewRef(py_module)) })
+            Ok(unsafe { pyffi::_Py_NewRef(py_module) })
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -199,7 +199,7 @@ fn load_dynamic_library(
         return if py_module.is_null() {
             Err(PyErr::fetch(py))
         } else {
-            Ok(unsafe { PyObject::from_borrowed_ptr(py, py_module) })
+            Ok(unsafe { PyObject::from_borrowed_ptr(py, py_module) }) //This is to match description of PEP
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -199,7 +199,7 @@ pyffi::PyErr_Occurred().is_null() } {
             Err(PyErr::fetch(py))
         } else {
             println!("going to borrow ref.. multiphase");
-            Ok(unsafe { py_module}) //This is to match description of PEP
+            Ok(unsafe { py_module}); //This is to match description of PEP
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -205,7 +205,7 @@ fn load_dynamic_library(
 
     // Else fall back to single-phase init mechanism.
 
-    let mut module_def = unsafe { pyffi::Py_DECREF(py_module); // undo the newref call which was needed to suport multiphase initialisation 
+    let mut module_def = unsafe { pyffi::Py_DECREF(py_module.as_ptr()); // undo the newref call which was needed to suport multiphase initialisation 
                                   pyffi::PyModule_GetDef(py_module.as_ptr()) };
     if module_def.is_null() {
         return Err(PySystemError::new_err(format!(

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -200,9 +200,7 @@ fn load_dynamic_library(
             Err(PyErr::fetch(py))
         } else {
             println!("going to incref.. multiphase");
-            unsafe {pyffi::Py_INCREF(py_module)};
-            println!("did incref.. multiphase");
-            Ok(unsafe { PyObject::from_owned_ptr(py, py_module) })
+            Ok(unsafe { PyObject::from_owned_ptr(py, pyffi::_Py_NewRef(py_module)) })
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -152,12 +152,12 @@ fn load_dynamic_library(
     let init_fn: py_init_fn = unsafe { std::mem::transmute(address) };
 
     // Package context is needed for single-phase init.
-    let py_module = unsafe {
+    let py_module_initial_handle = unsafe {
         let old_context = pyffi::_Py_PackageContext;
         pyffi::_Py_PackageContext = name_cstring.as_ptr();
         let py_module = init_fn();
         pyffi::_Py_PackageContext = old_context;
-        pyffi::_Py_NewRef(py_module)
+        pyffi::_Py_XNewRef(py_module)
     };
 
     if py_module.is_null() && unsafe { pyffi::PyErr_Occurred().is_null() } {
@@ -199,15 +199,14 @@ fn load_dynamic_library(
         return if py_module.is_null() {
             Err(PyErr::fetch(py))
         } else {
-            println!("going to incref.. multiphase");
-            Ok(unsafe { PyObject::from_owned_ptr(py, py_module)})
+            Ok(unsafe { PyObject::from_owned_ptr(py, py_module) })
         };
     }
 
     // Else fall back to single-phase init mechanism.
-    println!("single phase");
-            
-    let mut module_def = unsafe { pyffi::PyModule_GetDef(py_module.as_ptr()) };
+
+    let mut module_def = unsafe { pyffi::Py_DECREF(py_module); // undo the newref call which was needed to suport multiphase initialisation 
+                                  pyffi::PyModule_GetDef(py_module.as_ptr()) };
     if module_def.is_null() {
         return Err(PySystemError::new_err(format!(
             "initialization of {} did not return an extension module",

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -157,7 +157,7 @@ fn load_dynamic_library(
         pyffi::_Py_PackageContext = name_cstring.as_ptr();
         let py_module = init_fn();
         pyffi::_Py_PackageContext = old_context;
-        py_module
+        pyffi::_Py_NewRef(py_module)
     };
 
     if py_module.is_null() && unsafe { pyffi::PyErr_Occurred().is_null() } {
@@ -200,7 +200,7 @@ fn load_dynamic_library(
             Err(PyErr::fetch(py))
         } else {
             println!("going to incref.. multiphase");
-            Ok(unsafe { pyffi::_Py_NewRef(py_module) })
+            Ok(unsafe { PyObject::from_owned_ptr(py, py_module)})
         };
     }
 

--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -200,7 +200,7 @@ fn load_dynamic_library(
             Err(PyErr::fetch(py))
         } else {
             println!("going to incref.. multiphase");
-            pyffi::Py_INCREF(py_module);
+            unsafe {pyffi::Py_INCREF(py_module)};
             println!("did incref.. multiphase");
             Ok(unsafe { PyObject::from_owned_ptr(py, py_module) })
         };


### PR DESCRIPTION
according to https://docs.python.org/3/c-api/module.html:

PyModuleDef_Init returns a borrowed ref, while PyModule_Create returns a new ref.

To my understanding, we need to use the from_borrowed_ptr, as the returned reference should keep the object allive.

I have tried a mockup of this test on my local machine using.:
   
    PyObject *module;
    module =  PyModuleDef_Init(&spam_def);
    Py_INCREF(module);
    return module;

Which loads. So it apears to be the case that pyoxidizer should increment the ref count in this situation, which this PR tries to achieve.

I was unable to compile this on my local machine, hopefully CI can help.

This is an atempt on this issue: https://github.com/indygreg/PyOxidizer/issues/490