### PR TITLE
Enable multiphase initialisation using incref

### DIFF
--- a/python-oxidized-importer/src/importer.rs
+++ b/python-oxidized-importer/src/importer.rs
@@ -199,7 +199,7 @@ fn load_dynamic_library(
         return if py_module.is_null() {
             Err(PyErr::fetch(py))
         } else {
-            Ok(unsafe { PyObject::from_owned_ptr(py, py_module) })
+            Ok(unsafe { PyObject::from_borrowed_ptr(py, py_module) })
         };
     }
 


### PR DESCRIPTION
I encountered issues when loading multi phase initialisation modules, like numpy.random in single file executables.

This patch fixes these issues for me, however i have the impression that this could be written in a better way. The newref/decref pair feels not very elegant.