### PR TITLE
Write `extra_files` when building pyembed artifacts v2

### DIFF
--- a/pyoxidizer/src/starlark/python_embedded_resources.rs
+++ b/pyoxidizer/src/starlark/python_embedded_resources.rs
@@ -58,7 +58,7 @@ impl PythonEmbeddedResourcesValue {
         context: &PyOxidizerEnvironmentContext,
     ) -> Result<ResolvedTarget> {
         let output_path = context
-            .get_output_path(type_values, target)
+            .build_path(type_values)
             .map_err(|_| anyhow!("unable to resolve output path"))?;
 
         warn!(

--- a/pyoxidizer/src/starlark/python_embedded_resources.rs
+++ b/pyoxidizer/src/starlark/python_embedded_resources.rs
@@ -76,6 +76,7 @@ impl PythonEmbeddedResourcesValue {
         std::fs::create_dir_all(&output_path)
             .with_context(|| format!("creating output directory: {}", output_path.display()))?;
         embedded.write_files(&output_path)?;
+        embedded.write_extra_files(&output_path)?;
 
         Ok(ResolvedTarget {
             run_mode: RunMode::None,


### PR DESCRIPTION
These are the changes I needed in order to enable the workflow described in #498 when packaging `filesystem-relative` files via `run-build-script`:

1. Write the artifacts directly to `OUT_DIR` and skip copying them from the `build/` directory.
2. Write `extra_files` to a zstd-compressed tar archive.

Using an archive rather than materializing extra files directly is an improvement on #466, which makes the process faster and simplifies moving the files to their final destination. It also enables the use case where the archive is compiled into the final binary via `include_bytes!` and then extracted at runtime to always be in the right place. This allows the entire application to still be distributed as a single binary.

I'm intentionally not calling `write_extra_files` from `write_files` because the archive is only needed as the output of `run-build-script`.