### PR TITLE
Update docs and bzl template to filter_resources_from_files

### DIFF
--- a/pyoxidizer/docs/pyoxidizer_config_type_python_executable.rst
+++ b/pyoxidizer/docs/pyoxidizer_config_type_python_executable.rst
@@ -281,7 +281,7 @@
         This method is identical to :py:meth:`add_python_resource` except the argument is
         an iterable of resources. All other arguments are identical.
 
-    .. py:method:: filter_from_files(files: list[str], glob_files: list[str])
+    .. py:method:: filter_resources_from_files(files: list[str], glob_files: list[str])
 
         This method filters all embedded resources (source modules, bytecode modules,
         and resource names) currently present on the instance through a set of

--- a/pyoxidizer/src/templates/new-pyoxidizer.bzl.hbs
+++ b/pyoxidizer/src/templates/new-pyoxidizer.bzl.hbs
@@ -269,7 +269,7 @@ def make_exe():
 
     # Filter all resources collected so far through a filter of names
     # in a file.
-    #exe.filter_from_files(files=["/path/to/filter-file"]))
+    #exe.filter_resources_from_files(files=["/path/to/filter-file"]))
 
     # Return our `PythonExecutable` instance so it can be built and
     # referenced by other consumers of this target.


### PR DESCRIPTION
It looks like [this function](https://github.com/indygreg/PyOxidizer/blob/4c2f416996dd7013fdc91713802940ef828ae279/pyoxidizer/src/starlark/python_executable.rs#L962) was renamed at some point but didn't get updated in the docs or the bzl template.

I think this resolves #222.