### PR TITLE
pyembed: Fix types for linux/aarch64

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -85,6 +85,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "jemalloc-sys",
+ "libc",
  "libmimalloc-sys",
  "once_cell",
  "pathdiff",

--- a/pyembed/.cargo/config
+++ b/pyembed/.cargo/config
@@ -12,6 +12,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 

--- a/pyembed/Cargo.toml
+++ b/pyembed/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 anyhow = "1.0"
 dunce = "1.0"
 jemalloc-sys = { version = "0.3", optional = true }
+libc = "0.2"
 once_cell = "1.7"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/pyembed/src/conversion.rs
+++ b/pyembed/src/conversion.rs
@@ -7,6 +7,7 @@
 use pyo3::{ffi as pyffi, prelude::*};
 
 use std::ffi::OsString;
+use std::os::raw::c_char;
 
 #[cfg(target_family = "unix")]
 use std::os::unix::ffi::OsStrExt;
@@ -18,7 +19,7 @@ use std::os::windows::prelude::OsStrExt;
 pub fn osstring_to_bytes(py: Python, s: OsString) -> &PyAny {
     let b = s.as_bytes();
     unsafe {
-        let o = pyffi::PyBytes_FromStringAndSize(b.as_ptr() as *const i8, b.len() as isize);
+        let o = pyffi::PyBytes_FromStringAndSize(b.as_ptr() as *const c_char, b.len() as isize);
         PyObject::from_owned_ptr(py, o).into_ref(py)
     }
 }
@@ -27,7 +28,7 @@ pub fn osstring_to_bytes(py: Python, s: OsString) -> &PyAny {
 pub fn osstring_to_bytes(py: Python, s: OsString) -> &PyAny {
     let w: Vec<u16> = s.encode_wide().collect();
     unsafe {
-        let o = pyffi::PyBytes_FromStringAndSize(w.as_ptr() as *const i8, w.len() as isize * 2);
+        let o = pyffi::PyBytes_FromStringAndSize(w.as_ptr() as *const c_char, w.len() as isize * 2);
         PyObject::from_owned_ptr(py, o).into_ref(py)
     }
 }

--- a/pyembed/src/interpreter.rs
+++ b/pyembed/src/interpreter.rs
@@ -28,6 +28,7 @@ use {
         env, fs,
         io::Write,
         path::{Path, PathBuf},
+        os::raw::c_char,
     },
 };
 
@@ -391,7 +392,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
             let argvb = b"argvb\0";
 
             let res = args.with_borrowed_ptr(py, |args_ptr| unsafe {
-                pyffi::PySys_SetObject(argvb.as_ptr() as *const i8, args_ptr)
+                pyffi::PySys_SetObject(argvb.as_ptr() as *const c_char, args_ptr)
             });
 
             match res {
@@ -405,7 +406,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
         let oxidized = b"oxidized\0";
 
         let res = true.into_py(py).with_borrowed_ptr(py, |py_true| unsafe {
-            pyffi::PySys_SetObject(oxidized.as_ptr() as *const i8, py_true)
+            pyffi::PySys_SetObject(oxidized.as_ptr() as *const c_char, py_true)
         });
 
         match res {
@@ -417,7 +418,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
             let frozen = b"frozen\0";
 
             match true.into_py(py).with_borrowed_ptr(py, |py_true| unsafe {
-                pyffi::PySys_SetObject(frozen.as_ptr() as *const i8, py_true)
+                pyffi::PySys_SetObject(frozen.as_ptr() as *const c_char, py_true)
             }) {
                 0 => (),
                 _ => return Err(NewInterpreterError::Simple("unable to set sys.frozen")),
@@ -429,7 +430,7 @@ impl<'interpreter, 'resources> MainPythonInterpreter<'interpreter, 'resources> {
             let value = self.config.origin().display().to_string().to_object(py);
 
             match value.with_borrowed_ptr(py, |py_value| unsafe {
-                pyffi::PySys_SetObject(meipass.as_ptr() as *const i8, py_value)
+                pyffi::PySys_SetObject(meipass.as_ptr() as *const c_char, py_value)
             }) {
                 0 => (),
                 _ => return Err(NewInterpreterError::Simple("unable to set sys._MEIPASS")),

--- a/pyembed/src/interpreter_config.rs
+++ b/pyembed/src/interpreter_config.rs
@@ -16,21 +16,14 @@ use {
         ffi::{CString, OsString},
         path::Path,
     },
+    libc::wchar_t,
 };
 
 #[cfg(target_family = "unix")]
 use std::{ffi::NulError, os::unix::ffi::OsStrExt};
 
-#[allow(non_camel_case_types)]
-#[cfg(target_family = "unix")]
-type wchar_t = i32;
-
 #[cfg(target_family = "windows")]
 use std::os::windows::prelude::OsStrExt;
-
-#[allow(non_camel_case_types)]
-#[cfg(target_family = "windows")]
-type wchar_t = u16;
 
 /// Set a PyConfig string value from a str.
 fn set_config_string_from_str(

--- a/pyoxidizer/src/new-project-cargo.lock
+++ b/pyoxidizer/src/new-project-cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "jemalloc-sys",
+ "libc",
  "libmimalloc-sys",
  "once_cell",
  "pyo3",

--- a/pyoxidizer/src/projectmgmt.rs
+++ b/pyoxidizer/src/projectmgmt.rs
@@ -41,7 +41,11 @@ use {
 pub fn default_target() -> Result<String> {
     // TODO derive these more intelligently.
     if cfg!(target_os = "linux") {
-        Ok("x86_64-unknown-linux-gnu".to_string())
+        if cfg!(target_arch = "aarch64") {
+            Ok("aarch64-unknown-linux-gnu".to_string())
+        } else {
+            Ok("x86_64-unknown-linux-gnu".to_string())
+        }
     } else if cfg!(target_os = "windows") {
         Ok("x86_64-pc-windows-msvc".to_string())
     } else if cfg!(target_os = "macos") {

--- a/pyoxidizer/src/templates/new-cargo-config.hbs
+++ b/pyoxidizer/src/templates/new-cargo-config.hbs
@@ -15,6 +15,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 

--- a/pyoxy/.cargo/config.toml
+++ b/pyoxy/.cargo/config.toml
@@ -18,6 +18,9 @@ rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
 
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-Wl,-export-dynamic"]
+
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-rdynamic"]
 


### PR DESCRIPTION
The c_char and wchar_t types on linux/aarch64 are unsigned, so some
casts to "*const i8" were turned to "*const c_char" and the type
definition for wchar_t to be used from libc.
libc was a transient dependency (from pyo3 at least) and is now direct.
Also fixes default_target to return the correct value on linux/aarch64.