### PR TITLE
Remove py builtin define

### DIFF
--- a/pyoxidizer/src/distutils/command/build_ext.py
+++ b/pyoxidizer/src/distutils/command/build_ext.py
@@ -526,8 +526,9 @@ class build_ext(Command):
             macros.append((undef,))
 
         # This is needed to activate specific symbol visibility / linking
-        # behavior on Windows. It isn't needed on UNIX but should be harmless.
-        macros.append(('Py_BUILD_CORE_BUILTIN', '1'))
+        # behavior on Windows.
+        if os.name == 'nt':
+            macros.append(('Py_BUILD_CORE_BUILTIN', '1'))
 
         objects = self.compiler.compile(sources,
                                          output_dir=self.build_temp,


### PR DESCRIPTION
This flag causes errors when building the `grpcio` package from source, because it changes what header needs to be included for some internal GC structs. The comment says it is only needed for windows, so checking for that, but the issue probably happens on windows as well, it is just an easy fix for other platforms.