### PR TITLE
[pyembed] Add support for `PYTHONPATH` support in `Python` profile when loading resources from filesystem

### DIFF
--- a/pyembed/src/interpreter_config.rs
+++ b/pyembed/src/interpreter_config.rs
@@ -496,6 +496,21 @@ pub fn python_interpreter_config_to_py_config(
                 "setting module_search_paths",
             )?;
         }
+
+        // Make sure to append `$PYTHONPATH` if the current profile is not isolated since setting
+        // `module_search_paths_set` to 1 means that Python will not expand and add it to
+        // `sys.path` for us.
+        if let PythonInterpreterProfile::Python = value.profile {
+            if let Ok(path) = std::env::var("PYTHONPATH") {
+                for path in std::env::split_paths(&path) {
+                    append_wide_string_list_from_path(
+                        &mut config.module_search_paths,
+                        &path,
+                        "setting module_search_paths",
+                    )?;
+                }
+            }
+        }
     }
     if let Some(executable) = &value.executable {
         set_config_string_from_path(


### PR DESCRIPTION
When using the regular `Python` profile (that is not isolated) one would
expect paths specified in the `PYTHONPATH` environment variable to be
appended to `sys.path`.

This works as expected when using the `in-memory` resources loader.

However, when loading resources from the filesystem in PyOxidizer, one
has to pass the path to the resources in `module_search_paths` and that
leads us to set these paths in the `PyConfig` itself and thus also
setting `module_search_paths_set` to 1, which leads Python to not add
the usual paths to `sys.path` and thus not expanding `PYTHONPATH` into
it either...

This patch reads `PYTHONPATH` manually and adds it to the
`module_search_paths` in `pyembed` whenever the profile is set to
`Python` *and* `module_search_paths` was set in the configuration.

Note that I'm not familiar enough with the codebase to know whether this
is the best place to do this check but it looked like a reasonable place.