### PR TITLE
apple-flat-package: make version a string

### DIFF
--- a/apple-flat-package/src/package_info.rs
+++ b/apple-flat-package/src/package_info.rs
@@ -75,7 +75,7 @@ pub struct PackageInfo {
     ///
     /// This is the version of the package itself, not the version of the application
     /// being installed.
-    pub version: u32,
+    pub version: String,
 
     // End of attributes. Beginning of elements.
     #[serde(default)]
@@ -135,7 +135,7 @@ impl Default for PackageInfo {
             preserve_xattr: None,
             relocatable: None,
             use_hfs_plus_compression: None,
-            version: 0,
+            version: "0".to_string(),
             atomic_update_bundle: vec![],
             bundle: vec![],
             bundle_version: vec![],


### PR DESCRIPTION
[PackageInfo version](https://github.com/indygreg/PyOxidizer/blob/72ecaa846f40d2dcb18464c9a9c6d838654bbb7d/apple-flat-package/src/package_info.rs#L78) is typed as `u32` but it could be actually an `string` ([reference](http://s.sudre.free.fr/Stuff/Ivanhoe/FLAT.html)). For example, a semantic version (like `2.12.2`) is a valid version.

Fixes: #571