### PR TITLE
apple-codesign: add support for component notarization

### DIFF
--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -464,9 +464,17 @@ pub fn write_flat_package_to_app_store_package<F: Read + Seek + Debug>(
         id
     } else if let Some(_component) = pkg.root_component()? {
         warn!("notarizing a component installer");
+        
+        // We need to extract the primary component identifier from the `PackageInfo` XML.
+        let id = match _component.package_info() {
+            Some(_pkginfo) => _pkginfo.identifier.clone(),
+            None => {
+                error!("unable to find package identifier in component package (please report this bug)");
+                return Err(AppleCodesignError::NotarizeFlatPackageParse);
+            },
+        };
 
-        error!("support for notarizing a component installer is not yet implemented");
-        return Err(AppleCodesignError::NotarizeFlatPackageParse);
+        id
     } else {
         error!("do not know how to extract bundle identifier from package installer");
         error!("please report this bug");


### PR DESCRIPTION
I'm not completely sure this is covering all the use cases, but it works for us where we have an `Installer.pkg` that contains:
```
Installer.pkg
├── Bom
├── PackageInfo
├── Payload
└── Scripts
    ├── postinstall
    └── preinstall
```