### PR TITLE
569 fix python version slicing

### DIFF
--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -256,6 +256,16 @@ fn parse_python_json_from_distribution(dist_dir: &Path) -> Result<PythonJsonMain
     parse_python_json(&python_json_path)
 }
 
+fn parse_python_major_minor_version(version: &str) -> String {
+    let mut at_least_minor_version = String::from(version);
+    if !version.contains(".") {
+        at_least_minor_version.push_str(".0");
+    }
+    at_least_minor_version.split('.').take(2)
+        .collect::<Vec<&str>>()
+        .join(".")
+}
+
 /// Resolve the path to a `python` executable in a Python distribution.
 pub fn python_exe_path(dist_dir: &Path) -> Result<PathBuf> {
     let pi = parse_python_json_from_distribution(dist_dir)?;
@@ -296,7 +306,7 @@ pub fn resolve_python_paths(base: &Path, python_version: &str) -> PythonPaths {
 
     let unix_lib_dir = p
         .join("lib")
-        .join(format!("python{}", &python_version));
+        .join(format!("python{}", parse_python_major_minor_version(&python_version)));
 
     let stdlib = if unix_lib_dir.exists() {
         unix_lib_dir
@@ -1171,8 +1181,7 @@ impl PythonDistribution for StandaloneDistribution {
     }
 
     fn python_major_minor_version(&self) -> String {
-        let parts = self.version.split('.').take(2).collect::<Vec<_>>();
-        parts.join(".")
+        parse_python_major_minor_version(&self.version)
     }
 
     fn python_implementation(&self) -> &str {

--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -274,7 +274,7 @@ pub struct PythonPaths {
 }
 
 /// Resolve the location of Python modules given a base install path.
-pub fn resolve_python_paths(base: &Path, python_version: &str) -> PythonPaths {
+pub fn resolve_python_paths(base: &Path, python_major_minor_version: &str) -> PythonPaths {
     let prefix = base.to_path_buf();
 
     let p = prefix.clone();
@@ -296,7 +296,7 @@ pub fn resolve_python_paths(base: &Path, python_version: &str) -> PythonPaths {
 
     let unix_lib_dir = p
         .join("lib")
-        .join(format!("python{}", &python_version));
+        .join(format!("python{}", &python_major_minor_version));
 
     let stdlib = if unix_lib_dir.exists() {
         unix_lib_dir
@@ -1044,7 +1044,7 @@ impl StandaloneDistribution {
             );
         }
 
-        let python_paths = resolve_python_paths(&venv_base, &self.version);
+        let python_paths = resolve_python_paths(&venv_base, &self.python_major_minor_version());
 
         invoke_python(&python_paths, &["-m", "ensurepip"]);
 
@@ -1068,7 +1068,7 @@ impl StandaloneDistribution {
             invoke_python(&python_paths, &["-m", "venv", venv_dir_s.as_str()]);
         }
 
-        resolve_python_paths(path, &self.version)
+        resolve_python_paths(path, &self.python_major_minor_version())
     }
 
     /// Create or re-use an existing venv
@@ -1377,7 +1377,7 @@ impl PythonDistribution for StandaloneDistribution {
     /// Ensure pip is available to run in the distribution.
     fn ensure_pip(&self) -> Result<PathBuf> {
         let dist_prefix = self.base_dir.join("python").join("install");
-        let python_paths = resolve_python_paths(&dist_prefix, &self.version);
+        let python_paths = resolve_python_paths(&dist_prefix, &self.python_major_minor_version());
 
         let pip_path = python_paths.bin_dir.join(PIP_EXE_BASENAME);
 

--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -296,7 +296,7 @@ pub fn resolve_python_paths(base: &Path, python_version: &str) -> PythonPaths {
 
     let unix_lib_dir = p
         .join("lib")
-        .join(format!("python{}", &python_version[0..3]));
+        .join(format!("python{}", &python_version));
 
     let stdlib = if unix_lib_dir.exists() {
         unix_lib_dir

--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -274,7 +274,7 @@ pub struct PythonPaths {
 }
 
 /// Resolve the location of Python modules given a base install path.
-pub fn resolve_python_paths(base: &Path, python_major_minor_version: &str) -> PythonPaths {
+pub fn resolve_python_paths(base: &Path, python_version: &str) -> PythonPaths {
     let prefix = base.to_path_buf();
 
     let p = prefix.clone();
@@ -296,7 +296,7 @@ pub fn resolve_python_paths(base: &Path, python_major_minor_version: &str) -> Py
 
     let unix_lib_dir = p
         .join("lib")
-        .join(format!("python{}", &python_major_minor_version));
+        .join(format!("python{}", &python_version));
 
     let stdlib = if unix_lib_dir.exists() {
         unix_lib_dir
@@ -1044,7 +1044,7 @@ impl StandaloneDistribution {
             );
         }
 
-        let python_paths = resolve_python_paths(&venv_base, &self.python_major_minor_version());
+        let python_paths = resolve_python_paths(&venv_base, &self.version);
 
         invoke_python(&python_paths, &["-m", "ensurepip"]);
 
@@ -1068,7 +1068,7 @@ impl StandaloneDistribution {
             invoke_python(&python_paths, &["-m", "venv", venv_dir_s.as_str()]);
         }
 
-        resolve_python_paths(path, &self.python_major_minor_version())
+        resolve_python_paths(path, &self.version)
     }
 
     /// Create or re-use an existing venv
@@ -1377,7 +1377,7 @@ impl PythonDistribution for StandaloneDistribution {
     /// Ensure pip is available to run in the distribution.
     fn ensure_pip(&self) -> Result<PathBuf> {
         let dist_prefix = self.base_dir.join("python").join("install");
-        let python_paths = resolve_python_paths(&dist_prefix, &self.python_major_minor_version());
+        let python_paths = resolve_python_paths(&dist_prefix, &self.version);
 
         let pip_path = python_paths.bin_dir.join(PIP_EXE_BASENAME);
 

--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -1632,4 +1632,31 @@ pub mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_parse_python_major_minor_version() {
+        let version_expectations = [
+            ("3.7.1", "3.7"), ("3.10.1", "3.10"), ("1.2.3.4.5", "1.2"), ("1", "1.0")
+        ];
+        for (version, expected) in version_expectations {
+            assert_eq!(parse_python_major_minor_version(version), expected);
+        }
+    }
+
+    #[test]
+    fn test_resolve_python_paths_site_packages() -> Result<()> {
+        let python_paths = resolve_python_paths(
+            Path::new("/test/dir"), "3.10.4",
+        );
+        assert_eq!(
+            python_paths.site_packages.to_str().unwrap(), "/test/dir/lib/python3.10/site-packages"
+        );
+        let python_paths = resolve_python_paths(
+            Path::new("/test/dir"), "3.9.1"
+        );
+        assert_eq!(
+            python_paths.site_packages.to_str().unwrap(), "/test/dir/lib/python3.9/site-packages"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Hi, this is a fix for #569 


The issue was that the python version was being sliced to exactly 3 characters long, which doesn't work for "3.10". ~~This fix removes the slicing and replaces the leftover parameter use of `version` with `python_major_minor_version()`, as other places already use it like this.~~

~~This fix should work, but does not improve the resiliency of the `resolve_python_paths` function, which could then be incorrectly used in the future. There are of course a few options available to improve that, like copying the `python_major_minor_version` method logic into the mentioned function, or consolidating the logic for both methods somewhere in another function.~~

Since I'm new to the project I'd love to hear your thoughts before going in too deep for a small bug fix. :wink: 

Thanks for this great project btw! :+1: 

Edit: I've gone ahead and consolidated the logic into a new function. 