### PR TITLE
debian-packaging: Derive hash for PackageVersion

### DIFF
--- a/debian-packaging/src/package_version.rs
+++ b/debian-packaging/src/package_version.rs
@@ -39,7 +39,7 @@ use {
 ///
 /// assert!(v < PackageVersion::parse("1:4.7.0+dfsg1-3").unwrap());
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct PackageVersion {
     epoch: Option<u32>,
     upstream_version: String,


### PR DESCRIPTION
Useful when e.g. when wanting to stick package name + version in a hash
table.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>