### PR TITLE
apple-codesign/README: Fix rcodesign remote install command line

### DIFF
--- a/apple-codesign/README.md
+++ b/apple-codesign/README.md
@@ -36,7 +36,7 @@ $ cargo run --bin rcodesign -- --help
 $ cargo install --bin rcodesign
 
 # Remote install.
-$ cargo install --git https://github.com/indygreg/PyOxidizer --branch main rcodesign
+$ cargo install --git https://github.com/indygreg/PyOxidizer --branch main --bin rcodesign apple-codesign
 ```
 
 # Project Relationship


### PR DESCRIPTION
The previous command line produced the error:

```
error: could not find `rcodesign` in https://github.com/indygreg/PyOxidizer?branch=main with version `*`
```