### PR TITLE
Correct sorting and allow signed data without content

### DIFF
--- a/cryptographic-message-syntax/Cargo.toml
+++ b/cryptographic-message-syntax/Cargo.toml
@@ -20,6 +20,11 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 ring = "0.16"
 signature = "1.3"
 
+[features]
+default = []
+# Do not insert content (that was hashed) into `SignedData`
+no_content = []
+
 [dependencies.x509-certificate]
 path = "../x509-certificate"
 version = "0.14.0-pre"

--- a/cryptographic-message-syntax/Cargo.toml
+++ b/cryptographic-message-syntax/Cargo.toml
@@ -20,11 +20,6 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 ring = "0.16"
 signature = "1.3"
 
-[features]
-default = []
-# Do not insert content (that was hashed) into `SignedData`
-no_content = []
-
 [dependencies.x509-certificate]
 path = "../x509-certificate"
 version = "0.14.0-pre"

--- a/cryptographic-message-syntax/src/lib.rs
+++ b/cryptographic-message-syntax/src/lib.rs
@@ -78,6 +78,8 @@ mod time_stamp_protocol;
 pub use {
     signing::{SignedDataBuilder, SignerBuilder},
     time_stamp_protocol::{time_stamp_message_http, time_stamp_request_http, TimeStampError},
+    bytes::Bytes,
+    bcder::Oid,
 };
 
 use {
@@ -88,7 +90,7 @@ use {
             OID_SIGNING_TIME,
         },
     },
-    bcder::{Integer, OctetString, Oid},
+    bcder::{Integer, OctetString},
     pem::PemError,
     ring::{digest::Digest, signature::UnparsedPublicKey},
     std::{

--- a/cryptographic-message-syntax/src/lib.rs
+++ b/cryptographic-message-syntax/src/lib.rs
@@ -78,7 +78,7 @@ mod time_stamp_protocol;
 pub use {
     bcder::Oid,
     bytes::Bytes,
-    signing::{SignedDataBuilder, SignerBuilder},
+    signing::{SignedContent, SignedDataBuilder, SignerBuilder},
     time_stamp_protocol::{time_stamp_message_http, time_stamp_request_http, TimeStampError},
 };
 

--- a/cryptographic-message-syntax/src/lib.rs
+++ b/cryptographic-message-syntax/src/lib.rs
@@ -76,10 +76,10 @@ mod signing;
 mod time_stamp_protocol;
 
 pub use {
+    bcder::Oid,
+    bytes::Bytes,
     signing::{SignedDataBuilder, SignerBuilder},
     time_stamp_protocol::{time_stamp_message_http, time_stamp_request_http, TimeStampError},
-    bytes::Bytes,
-    bcder::Oid,
 };
 
 use {


### PR DESCRIPTION
- Correct sorting of `signed_attributes`.
- Allow Signed data without content.
- Re-export `Bytes` and `Oid` so `SignedDataBuilder::content_type()` can be used without importing `bytes` and `bcder`.

( The `signed_attributes` Content type is move so they are all grouped together, this makes it easier to read. )