### PR TITLE
Fix compilation errors

### DIFF
--- a/apple-codesign/src/cryptography.rs
+++ b/apple-codesign/src/cryptography.rs
@@ -10,7 +10,7 @@ use {
         AppleCodesignError,
     },
     bytes::Bytes,
-    der::{asn1, Decodable, Document, Encodable},
+    der::{asn1, Document, Encodable},
     elliptic_curve::{
         sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
         AffinePoint, Curve, FieldSize, ProjectiveArithmetic, SecretKey as ECSecretKey,

--- a/apple-codesign/src/macho.rs
+++ b/apple-codesign/src/macho.rs
@@ -630,8 +630,6 @@ pub fn semver_to_macho_target_version(version: &semver::Version) -> u32 {
 
 /// Represents a semi-parsed Mach[-O] binary.
 pub struct MachFile<'a> {
-    data: &'a [u8],
-
     machos: Vec<MachOBinary<'a>>,
 }
 
@@ -663,7 +661,7 @@ impl<'a> MachFile<'a> {
             }
         };
 
-        Ok(Self { data, machos })
+        Ok(Self { machos })
     }
 
     /// Whether this Mach-O data has multiple architectures.


### PR DESCRIPTION
When compiling apple-codesign-0.17.0 on NetBSD with rust-1.60.0, I got the following errors:

```
warning: unused import: `Decodable`
  --> apple-codesign/src/cryptography.rs:13:17
   |
13 |     der::{asn1, Decodable, Document, Encodable},
   |                 ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: field is never read: `data`
   --> apple-codesign/src/macho.rs:633:5
    |
633 |     data: &'a [u8],
    |     ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```

The patches fix them for me.