### PR TITLE
Update `libtest-mimic` to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3047,14 +3047,13 @@ dependencies = [
 
 [[package]]
 name = "libtest-mimic"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc195aab5b803465bf614a5a4765741abce6c8d64e7d8ca57acd2923661fba9f"
+checksum = "79529479c298f5af41375b0c1a77ef670d450b4c9cd7949d2b43af08121b20ec"
 dependencies = [
  "clap 3.2.16",
- "crossbeam-channel",
- "rayon",
  "termcolor",
+ "threadpool",
 ]
 
 [[package]]
@@ -5613,6 +5612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/pyoxy/Cargo.toml
+++ b/pyoxy/Cargo.toml
@@ -26,7 +26,7 @@ features = ["serialization", "zipimport"]
 [dev-dependencies]
 assert_cmd = "2.0"
 glob = "0.3"
-libtest-mimic = "0.4"
+libtest-mimic = "0.5.2"
 predicates = "2.0"
 tempfile = "3.2"
 

--- a/pyoxy/tests/python.rs
+++ b/pyoxy/tests/python.rs
@@ -5,7 +5,7 @@
 use {
     anyhow::{Context, Result},
     assert_cmd::{cargo::cargo_bin, Command},
-    libtest_mimic::{run_tests, Arguments, Outcome, Test},
+    libtest_mimic::{Arguments, Trial},
     predicates::prelude::*,
 };
 
@@ -42,19 +42,6 @@ fn run() -> Result<()> {
 
 fn main() {
     let args = Arguments::from_args();
-
-    // libtest_mimic doesn't properly handle `--list --ignored`.
-    let tests: Vec<Test<()>> = if args.ignored {
-        vec![]
-    } else {
-        vec![Test::test("main")]
-    };
-
-    run_tests(&args, tests, |_| match run() {
-        Ok(_) => Outcome::Passed,
-        Err(e) => Outcome::Failed {
-            msg: Some(format!("{:?}", e)),
-        },
-    })
-    .exit();
+    let test = Trial::test("main", move || run().map_err(Into::into));
+    libtest_mimic::run(&args, vec![test]).exit();
 }

--- a/pyoxy/tests/yaml.rs
+++ b/pyoxy/tests/yaml.rs
@@ -5,7 +5,7 @@
 use {
     anyhow::Result,
     assert_cmd::Command,
-    libtest_mimic::{run_tests, Arguments, Outcome, Test},
+    libtest_mimic::{Arguments, Trial},
     predicates::prelude::*,
 };
 
@@ -30,19 +30,6 @@ fn run() -> Result<()> {
 
 fn main() {
     let args = Arguments::from_args();
-
-    // libtest_mimic doesn't properly handle `--list --ignored`.
-    let tests: Vec<Test<()>> = if args.ignored {
-        vec![]
-    } else {
-        vec![Test::test("main")]
-    };
-
-    run_tests(&args, tests, |_| match run() {
-        Ok(_) => Outcome::Passed,
-        Err(e) => Outcome::Failed {
-            msg: Some(format!("{:?}", e)),
-        },
-    })
-    .exit();
+    let test = Trial::test("main", move || run().map_err(Into::into));
+    libtest_mimic::run(&args, vec![test]).exit();
 }


### PR DESCRIPTION
I just released [a new version of libtest-mimic](https://github.com/LukasKalbertodt/libtest-mimic/releases/tag/v0.5.0). This is one of the bigger projects using it, so as a sanity check whether the new version still works for real world users, I just did this update. It allowed to remove some of the code here as the API changed a bit.

Two things to note:
- `libtest-mimic` requires Rust 1.58. 
- I do not know anything about this project at all and did not test anything except compiling and running the tests (via `cargo run -p pyoxy`). Please review carefully and/or test.