### PR TITLE
apple-codesign: zip notarization support

### DIFF
--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -202,6 +202,7 @@ impl Notarizer {
                 self.notarize_bundle(&bundle, wait_limit)
             }
             PathType::Xar => self.notarize_flat_package(path, wait_limit),
+            PathType::Zip => self.notarize_flat_package(path, wait_limit),
             PathType::Dmg => self.notarize_dmg(path, wait_limit),
             PathType::MachO | PathType::Other => Err(AppleCodesignError::NotarizeUnsupportedPath(
                 path.to_path_buf(),
@@ -248,7 +249,7 @@ impl Notarizer {
         )
     }
 
-    /// Attempt to notarize a flat package (`.pkg`) installer.
+    /// Attempt to notarize a flat package (`.pkg`) installer or a .zip file.
     pub fn notarize_flat_package(
         &self,
         pkg_path: &Path,

--- a/apple-codesign/src/signing.rs
+++ b/apple-codesign/src/signing.rs
@@ -42,7 +42,7 @@ impl<'key> UnifiedSigner<'key> {
             PathType::Dmg => self.sign_dmg(input_path, output_path),
             PathType::MachO => self.sign_macho(input_path, output_path),
             PathType::Xar => self.sign_xar(input_path, output_path),
-            PathType::Other => Err(AppleCodesignError::UnrecognizedPathType),
+            PathType::Zip | PathType::Other => Err(AppleCodesignError::UnrecognizedPathType),
         }
     }
 

--- a/apple-codesign/src/stapling.rs
+++ b/apple-codesign/src/stapling.rs
@@ -326,7 +326,7 @@ impl Stapler {
                 let xar = XarReader::new(File::options().read(true).write(true).open(path)?)?;
                 self.staple_xar(xar)
             }
-            PathType::Other => Err(AppleCodesignError::StapleUnsupportedPath(
+            PathType::Zip | PathType::Other => Err(AppleCodesignError::StapleUnsupportedPath(
                 path.to_path_buf(),
             )),
         }


### PR DESCRIPTION
Adds the ability to notarize .zip files containing other notarizable assets (such as a Mach-O binary).

Stapling (via the `staple` subcommand or `notary-submit --staple` option) is not supported for .zip files and will return an error.

Zip files are supported by the popular [gon](https://github.com/mitchellh/gon) tool which we were previously using. We would like to switch to rcodesign to sign our darwin release binaries but we can't as we don't release our CLI as a bundle, xar or dmg file.

```console
$ rcodesign sign --p12-file ./AppleDevCert_Production.p12 --p12-password-file ./cert-pw.txt --code-signature-flags runtime ./build/coder_darwin_arm64
...

$ zip x.zip build/coder_darwn_arm64
  adding: build/coder_darwin_arm64 (deflated 23%)

$ rcodesign notary-submit --api-key-path ./key.json --wait x.zip 
creating Notary API submission for x.zip (sha256: 309d5c53a47a45a07c1869171df7b1b136d1077f5f0e268373d2fefd18074b0d)
created submission ID: 51310405-3244-46cc-a2f3-efd83401bcbf
resolving AWS S3 configuration from Apple-provided credentials
uploading asset to s3://notary-submissions-prod/prod/AROARQRX7CZS3PRF6ZA5L:51310405-3244-46cc-a2f3-efd83401bcbf
(you may see additional log output from S3 client)
send_operation;
send_operation; operation="PutObject"
send_operation; service="s3"
send_operation; status="ok"
S3 upload completed successfully
waiting up to 600s for package upload 51310405-3244-46cc-a2f3-efd83401bcbf to finish processing
poll state after 0s: InProgress
poll state after 4s: InProgress
poll state after 7s: InProgress
poll state after 11s: InProgress
poll state after 15s: InProgress
poll state after 19s: InProgress
poll state after 22s: Accepted
Notary API Server has finished processing the uploaded asset
fetching notarization log for 51310405-3244-46cc-a2f3-efd83401bcbf
notary log> {
notary log>   "archiveFilename": "x.zip",
notary log>   "issues": null,
notary log>   "jobId": "51310405-3244-46cc-a2f3-efd83401bcbf",
notary log>   "logFormatVersion": 1,
notary log>   "sha256": "309d5c53a47a45a07c1869171df7b1b136d1077f5f0e268373d2fefd18074b0d",
notary log>   "status": "Accepted",
notary log>   "statusCode": 0,
notary log>   "statusSummary": "Ready for distribution",
notary log>   "ticketContents": [
notary log>     {
notary log>       "arch": "arm64",
notary log>       "cdhash": "181a64cf314e5f0fefd468aee3a0047992244d60",
notary log>       "digestAlgorithm": "SHA-256",
notary log>       "path": "x.zip/build/coder_darwin_arm64"
notary log>     }
notary log>   ],
notary log>   "uploadDate": "2022-09-06T07:48:23.895Z"
notary log> }
```