### PR TITLE
tugger-wix: Sanitise characters in Directory/ComponentGroup Id's.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,7 +2088,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -2561,7 +2570,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.28",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3843,13 +3852,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -3863,6 +3872,12 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "release"
@@ -5118,6 +5133,7 @@ dependencies = [
  "log",
  "msi",
  "once_cell",
+ "regex",
  "simple-file-manifest",
  "tempfile",
  "tugger-common",

--- a/tugger-wix/Cargo.toml
+++ b/tugger-wix/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.68"
 duct = "0.13.6"
 log = "0.4.17"
 once_cell = "1.17.0"
+regex = "1.8.4"
 simple-file-manifest = "0.11.0"
 url = "2.3.1"
 uuid = { version = "1.2.2", features = ["v4", "v5"] }


### PR DESCRIPTION
I'm using PyOxidizer msi functionality for the first time with an application using wxPython. This package has a bunch of files with `@` in the filenames which threw errors from wix:
```
D:\src\wsl-usbip-gui\build\x86_64-pc-windows-msvc\debug\msi_installer\wxs\install-files.wxs(6517) : error CNDL0014 : The DirectoryRef/@Id attribute's value, 'wsl_usb_gui.dir.lib.wx.locale.ca@valencia.LC_MESSAGES', is not a legal identifier.  Identifiers may contain ASCII characters A-Z, a-z, digits, underscores (_), or periods (.).  Every identifier must begin with either a letter or an underscore.

D:\src\wsl-usbip-gui\build\x86_64-pc-windows-msvc\debug\msi_installer\wxs\install-files.wxs(6524) : warning CNDL1126 : The ComponentGroup/@Id attribute contains invalid characters for an identifier. Being able to use invalid identifier characters for a ComponentGroup identifier has been deprecated.
```

I saw there was already some character cleanup in the `Id` generation for these elements, but it didn't quite cover everything. 

This PR enforces only the characters allowed according to the reported error above.