### PR TITLE
tugger-wix: Make msi option to add to path env optional.

### DIFF
--- a/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
+++ b/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
@@ -112,6 +112,13 @@
 
         Path to a file providing the icon for the installed application.
 
+    .. py:attribute:: add_to_path
+
+        (``bool``)
+
+        When set (on be default), provide an option in the msi installer wizard to 
+        add the application install folder to the system PATH environment.
+
     .. py:attribute:: upgrade_code
 
         (``str``)

--- a/tugger/src/starlark/wix_msi_builder.rs
+++ b/tugger/src/starlark/wix_msi_builder.rs
@@ -106,6 +106,9 @@ impl TypedValue for WiXMsiBuilderValue {
             "product_icon_path" => {
                 inner.builder = inner.builder.clone().product_icon_path(value.to_string());
             }
+            "add_to_path" => {
+                inner.builder = inner.builder.clone().add_to_path(value.to_bool());
+            }
             "upgrade_code" => {
                 inner.builder = inner.builder.clone().upgrade_code(value.to_string());
             }


### PR DESCRIPTION
When building / installing a GUI application, it's less common to want the install folder added to system env PATH.
This PR makes the inclusion of this checkbox in the msi installer optional, though enabled by default to not effect existing users.

Used like:
```
def make_msi(exe):
    msi = exe.to_wix_msi_builder(
        "wsl_usb_gui",
        "WSL USB",
        VARS.get("version"),
        "Andrew Leech"
    )
    msi.add_to_path = False

```