### PR TITLE
tugger-wix: Add option to set msi as per-user install rather than per-machine.

### DIFF
--- a/tugger-wix/src/simple_msi_builder.rs
+++ b/tugger-wix/src/simple_msi_builder.rs
@@ -48,6 +48,7 @@ pub struct WiXSimpleMsiBuilder {
     upgrade_code: Option<String>,
     package_keywords: Option<String>,
     package_description: Option<String>,
+    per_user_install: Option<bool>,
     license_source: Option<PathBuf>,
     product_icon: Option<PathBuf>,
     help_url: Option<String>,
@@ -137,6 +138,13 @@ impl WiXSimpleMsiBuilder {
     #[must_use]
     pub fn package_description(mut self, value: String) -> Self {
         self.package_description = Some(value);
+        self
+    }
+
+    /// If enabled install per-user rather than per-machine.
+    #[must_use]
+    pub fn per_user_install(mut self, value: bool) -> Self {
+        self.per_user_install = Some(value);
         self
     }
 
@@ -307,9 +315,14 @@ impl WiXSimpleMsiBuilder {
             .attr("InstallerVersion", &self.package_installer_version)
             .attr("Languages", &self.package_languages)
             .attr("Compressed", "yes")
-            .attr("InstallScope", "perMachine")
             .attr("SummaryCodepage", "1252")
             .attr("Platform", "$(sys.BUILDARCH)");
+
+        let package = if self.per_user_install.unwrap_or(false) {
+            package
+        } else {
+            package.attr("InstallScope", "perMachine")
+        };
 
         let package = if let Some(keywords) = &self.package_keywords {
             package.attr("Keywords", keywords)

--- a/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
+++ b/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
@@ -106,6 +106,13 @@
 
         Keywords for the application being installed.
 
+    .. py:attribute:: per_user_install
+
+        (``bool``)
+
+        When set (off be default) the application will be installed per-user 
+        rather than per-machine.
+
     .. py:attribute:: product_icon_path
 
         (``str``)

--- a/tugger/src/starlark/wix_msi_builder.rs
+++ b/tugger/src/starlark/wix_msi_builder.rs
@@ -103,6 +103,9 @@ impl TypedValue for WiXMsiBuilderValue {
             "package_keywords" => {
                 inner.builder = inner.builder.clone().package_keywords(value.to_string());
             }
+            "per_user_install" => {
+                inner.builder = inner.builder.clone().per_user_install(value.to_bool());
+            }
             "product_icon_path" => {
                 inner.builder = inner.builder.clone().product_icon_path(value.to_string());
             }


### PR DESCRIPTION
I'm migrating an existing application from a different msi build tool to pyoxidizer, and it turns out the old msi's don't have the per-machine install spec. This means that new msi's with `"InstallScope", "perMachine"` can't automatically uninstall existing installations (even with matching updadecode uuid).

This PR adds an optional flag `msi.per_user_install = True` to remove the per-machine spec, allowing it to fallback to default per-user.