### PR TITLE
tugger-wix: Add option to add start menu shortcut.

### DIFF
--- a/pyoxidizer/src/py_packaging/binary.rs
+++ b/pyoxidizer/src/py_packaging/binary.rs
@@ -168,6 +168,9 @@ pub trait PythonBinaryBuilder {
     /// The name of the binary.
     fn name(&self) -> String;
 
+    /// Set the name of the binary.
+    fn set_name(&mut self, value: &str) -> Result<()>;
+
     /// How the binary will link against libpython.
     fn libpython_link_mode(&self) -> LibpythonLinkMode;
 

--- a/pyoxidizer/src/py_packaging/standalone_builder.rs
+++ b/pyoxidizer/src/py_packaging/standalone_builder.rs
@@ -422,6 +422,12 @@ impl PythonBinaryBuilder for StandalonePythonExecutableBuilder {
         self.exe_name.clone()
     }
 
+    fn set_name(&mut self, value: &str) -> Result<()> {
+        self.exe_name = value.to_string();
+
+        Ok(())
+    }
+
     fn libpython_link_mode(&self) -> LibpythonLinkMode {
         self.link_mode
     }

--- a/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
+++ b/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
@@ -96,12 +96,19 @@
 
     .. py:attribute:: add_to_start_menu
 
-        (``str``)
+        (``bool``)
 
-        The filename (relative to install directory) to add as a shortcut in the Start Menu,
-        eg. ``msi.add_to_start_menu = "<exe.name>.exe"``
+        If enabled a shortcut wil be created in the Start Menu pointing to ``exe_name``
+        eg. ``msi.add_to_start_menu = True``
 
         If not set no shortcut will be installed.
+
+    .. py:attribute:: exe_name
+
+        (``str``)
+
+        The filename of the installed application, used by add_to_start_menu.
+        This is automatically set when using ``exe.to_wix_msi_builder()``.
 
     .. py:attribute:: package_description
 

--- a/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
+++ b/tugger/docs/tugger_starlark_type_wix_msi_builder.rst
@@ -94,6 +94,15 @@
 
         If not set, the default is ``<product_name>-<product_version>.msi``.
 
+    .. py:attribute:: add_to_start_menu
+
+        (``str``)
+
+        The filename (relative to install directory) to add as a shortcut in the Start Menu,
+        eg. ``msi.add_to_start_menu = "<exe.name>.exe"``
+
+        If not set no shortcut will be installed.
+
     .. py:attribute:: package_description
 
         (``str``)

--- a/tugger/src/starlark/wix_msi_builder.rs
+++ b/tugger/src/starlark/wix_msi_builder.rs
@@ -109,6 +109,9 @@ impl TypedValue for WiXMsiBuilderValue {
             "upgrade_code" => {
                 inner.builder = inner.builder.clone().upgrade_code(value.to_string());
             }
+            "add_to_start_menu" => {
+                inner.builder = inner.builder.clone().add_to_start_menu(value.to_string());
+            }
             attr => {
                 return Err(ValueError::OperationNotSupported {
                     op: UnsupportedOperation::SetAttr(attr.to_string()),

--- a/tugger/src/starlark/wix_msi_builder.rs
+++ b/tugger/src/starlark/wix_msi_builder.rs
@@ -110,7 +110,10 @@ impl TypedValue for WiXMsiBuilderValue {
                 inner.builder = inner.builder.clone().upgrade_code(value.to_string());
             }
             "add_to_start_menu" => {
-                inner.builder = inner.builder.clone().add_to_start_menu(value.to_string());
+                inner.builder = inner.builder.clone().add_to_start_menu(value.to_bool());
+            }
+            "set_exe_name" => {
+                let _ = inner.builder.set_exe_name(value.to_string());
             }
             attr => {
                 return Err(ValueError::OperationNotSupported {
@@ -326,6 +329,16 @@ impl WiXMsiBuilderValue {
         } else {
             inner.builder.default_msi_filename()
         })
+    }
+
+    pub fn set_exe_name(&mut self, exe_name: String) -> ValueResult {
+        const LABEL: &str = "WiXMSIBuilder.set_exe_name()";
+
+        let mut inner = self.inner(LABEL)?;
+
+        let _ = inner.builder.set_exe_name(exe_name);
+
+        Ok(Value::new(NoneType::None))
     }
 
     pub fn to_file_content(


### PR DESCRIPTION
This MR adds an msi option to create/install a start menu shortcut for the installed application.

So can be used like:
```
def make_msi(exe):
    msi = exe.to_wix_msi_builder(
        "wsl_usb_gui",
        "WSL USB",
        VARS.get("version"),
        "Andrew Leech"
    )
    add_to_start_menu = True
```