### PR TITLE
Allow persistant pyemed runtime projects

### DIFF
--- a/pyoxidizer/docs/pyoxidizer_config_type_python_distribution.rst
+++ b/pyoxidizer/docs/pyoxidizer_config_type_python_distribution.rst
@@ -84,7 +84,7 @@
         The policy automatically uses settings globally appropriate for the
         distribution.
 
-    .. py:method:: to_python_executable(name: str, packaging_policy: PythonPackagingPolicy, config: PythonInterpreterConfig) -> PythonExecutable
+    .. py:method:: to_python_executable(name: str, packaging_policy: PythonPackagingPolicy, config: PythonInterpreterConfig, runtime: str) -> PythonExecutable
 
         This method constructs a :py:class:`PythonExecutable` instance. It
         essentially says *build an executable embedding Python from this
@@ -106,6 +106,12 @@
            The default configuration of the embedded Python interpreter.
 
            Default is what :py:meth:`make_python_interpreter_config` returns.
+
+        ``runtime``
+           The path to a pyoxidizer Rust project that will invoke pyembed.
+           See :ref:`rust_projects` for more on the expected composition of Rust projects.
+
+           If not supplied, a temporary Rust project will be created.
 
         .. important::
 

--- a/pyoxidizer/docs/pyoxidizer_rust_projects.rst
+++ b/pyoxidizer/docs/pyoxidizer_rust_projects.rst
@@ -67,13 +67,14 @@ to ``exit()``. Succinctly, we instantiate and run an embedded Python
 interpreter. That's our executable.
 
 The ``pyoxidizer.bzl`` is our auto-generated
-:ref:`PyOxidizer configuration file <config_files>`.
+:ref:`PyOxidizer configuration file <config_files>` with an additional `runtime` option set to the current directory.
+This specifies that we want this project to be used as the pyembed runner instead of a temporary one.
 
 Crate Features
 ==============
 
 The auto-generated Rust project defines a number of features to control
-behavior. These are documented in the sections below.
+behavior when building via cargo. These are documented in the sections below.
 
 ``build-mode-standalone``
 -------------------------
@@ -127,7 +128,7 @@ name via the ``PYOXIDIZER_BUILD_TARGET`` environment variable. e.g.::
 
 This mode tells the build script to reuse artifacts that were already built.
 (Perhaps you called ``pyoxidizer build`` or ``pyoxidizer run-build-script``
-outside the context of a normal ``cargo build``.)
+outside the context of a normal ``cargo build``.) This is what is used when pyoxidizer invokes cargo as part of ``pyoxidizer build``.
 
 In this mode, the build script will look for artifacts in the directory
 specified by ``PYOXIDIZER_ARTIFACT_DIR`` if set, falling back to ``OUT_DIR``.

--- a/pyoxidizer/src/project_building.rs
+++ b/pyoxidizer/src/project_building.rs
@@ -463,6 +463,7 @@ pub fn build_python_executable<'a>(
                 None,
                 &[],
                 exe.windows_subsystem(),
+                false,
             )
             .context("initializing project")?;
 

--- a/pyoxidizer/src/project_layout.rs
+++ b/pyoxidizer/src/project_layout.rs
@@ -90,6 +90,7 @@ struct TemplateData {
     program_name: Option<String>,
     code: Option<String>,
     pip_install_simple: Vec<String>,
+    rust_init: bool,
 }
 
 impl TemplateData {
@@ -105,6 +106,7 @@ impl TemplateData {
             program_name: None,
             code: None,
             pip_install_simple: Vec::new(),
+            rust_init: false,
         }
     }
 }
@@ -285,12 +287,14 @@ pub fn write_new_pyoxidizer_config_file(
     name: &str,
     code: Option<&str>,
     pip_install: &[&str],
+    rust_init: bool,
 ) -> Result<()> {
     let path = project_dir.join("pyoxidizer.bzl");
 
     let mut data = TemplateData::new();
     populate_template_data(source, &mut data);
     data.program_name = Some(name.to_string());
+    data.rust_init = rust_init;
 
     if let Some(code) = code {
         // Replace " with \" to work around
@@ -421,6 +425,7 @@ pub fn initialize_project(
     code: Option<&str>,
     pip_install: &[&str],
     windows_subsystem: &str,
+    rust_init: bool,
 ) -> Result<()> {
     let status = std::process::Command::new(cargo_exe)
         .arg("init")
@@ -443,7 +448,7 @@ pub fn initialize_project(
     write_new_build_rs(&path.join("build.rs"), name).context("writing build.rs")?;
     write_new_main_rs(&path.join("src").join("main.rs"), windows_subsystem)
         .context("writing main.rs")?;
-    write_new_pyoxidizer_config_file(source, &path, name, code, pip_install)
+    write_new_pyoxidizer_config_file(source, &path, name, code, pip_install, rust_init)
         .context("writing PyOxidizer config file")?;
     write_application_manifest(&path, name).context("writing application manifest")?;
 

--- a/pyoxidizer/src/projectmgmt.rs
+++ b/pyoxidizer/src/projectmgmt.rs
@@ -315,7 +315,7 @@ pub fn init_config_file(
 
     let name = project_dir.iter().last().unwrap().to_str().unwrap();
 
-    write_new_pyoxidizer_config_file(source, project_dir, name, code, pip_install)?;
+    write_new_pyoxidizer_config_file(source, project_dir, name, code, pip_install, false)?;
 
     println!();
     println!("A new PyOxidizer configuration file has been created.");
@@ -347,6 +347,7 @@ pub fn init_rust_project(env: &Environment, project_path: &Path) -> Result<()> {
         None,
         &[],
         "console",
+        true,
     )?;
     println!();
     println!(

--- a/pyoxidizer/src/projectmgmt.rs
+++ b/pyoxidizer/src/projectmgmt.rs
@@ -617,6 +617,7 @@ pub fn generate_python_embedding_artifacts(
         BinaryLibpythonLinkMode::Default,
         &policy,
         &interpreter_config,
+        None,
         Some(host_dist.clone_trait()),
     )?;
 

--- a/pyoxidizer/src/py_packaging/binary.rs
+++ b/pyoxidizer/src/py_packaging/binary.rs
@@ -197,6 +197,9 @@ pub trait PythonBinaryBuilder {
     // TODO this should not need to exist if we properly supported cross-compiling.
     fn target_python_exe_path(&self) -> &Path;
 
+    /// The directory to install tcl/tk files into.
+    fn runtime_path(&self) -> &Option<String>;
+
     /// Apple SDK build/targeting information.
     fn apple_sdk_info(&self) -> Option<&AppleSdkInfo>;
 

--- a/pyoxidizer/src/py_packaging/config.rs
+++ b/pyoxidizer/src/py_packaging/config.rs
@@ -615,6 +615,7 @@ mod tests {
             &policy,
             &config,
             None,
+            None,
         )?;
 
         crate::project_building::build_python_executable(

--- a/pyoxidizer/src/py_packaging/distribution.rs
+++ b/pyoxidizer/src/py_packaging/distribution.rs
@@ -185,6 +185,7 @@ pub trait PythonDistribution {
         libpython_link_mode: BinaryLibpythonLinkMode,
         policy: &PythonPackagingPolicy,
         config: &PyembedPythonInterpreterConfig,
+        runtime_path: Option<String>,
         host_distribution: Option<Arc<dyn PythonDistribution>>,
     ) -> Result<Box<dyn PythonBinaryBuilder>>;
 

--- a/pyoxidizer/src/py_packaging/standalone_builder.rs
+++ b/pyoxidizer/src/py_packaging/standalone_builder.rs
@@ -130,6 +130,9 @@ pub struct StandalonePythonExecutableBuilder {
     /// Path to install tcl/tk files into.
     tcl_files_path: Option<String>,
 
+    /// Path to the Rust project that will invoke our embedded python interpreter.
+    runtime_path: Option<String>,
+
     /// Describes how Windows runtime DLLs should be handled during builds.
     windows_runtime_dlls_mode: WindowsRuntimeDllsMode,
 }
@@ -145,6 +148,7 @@ impl StandalonePythonExecutableBuilder {
         link_mode: BinaryLibpythonLinkMode,
         packaging_policy: PythonPackagingPolicy,
         config: PyembedPythonInterpreterConfig,
+        runtime_path: Option<String>,
     ) -> Result<Box<Self>> {
         let host_python_exe = host_distribution.python_exe_path().to_path_buf();
 
@@ -230,6 +234,7 @@ impl StandalonePythonExecutableBuilder {
             licenses_filename: Some("COPYING.txt".into()),
             windows_subsystem: "console".to_string(),
             tcl_files_path: None,
+            runtime_path,
             windows_runtime_dlls_mode: WindowsRuntimeDllsMode::WhenPresent,
         });
 
@@ -1211,6 +1216,7 @@ pub mod tests {
                 self.libpython_link_mode.clone(),
                 policy,
                 self.config.clone(),
+                None,
             )?;
 
             builder.add_distribution_resources(None)?;
@@ -3034,6 +3040,7 @@ pub mod tests {
                 BinaryLibpythonLinkMode::Default,
                 dist.create_packaging_policy()?,
                 dist.create_python_interpreter_config()?,
+                None,
             )?;
 
             let reqs = builder.vc_runtime_requirements();
@@ -3070,6 +3077,7 @@ pub mod tests {
                 BinaryLibpythonLinkMode::Default,
                 dist.create_packaging_policy()?,
                 dist.create_python_interpreter_config()?,
+                None,
             )?;
 
             // In Never mode, the set of extra files should always be empty.
@@ -3154,6 +3162,7 @@ pub mod tests {
             BinaryLibpythonLinkMode::Default,
             policy,
             dist.create_python_interpreter_config()?,
+            None,
         )?;
 
         builder.add_distribution_resources(None)?;

--- a/pyoxidizer/src/py_packaging/standalone_builder.rs
+++ b/pyoxidizer/src/py_packaging/standalone_builder.rs
@@ -469,6 +469,10 @@ impl PythonBinaryBuilder for StandalonePythonExecutableBuilder {
         self.target_distribution.python_exe_path()
     }
 
+    fn runtime_path(&self) -> &Option<String> {
+        &self.runtime_path
+    }
+
     fn apple_sdk_info(&self) -> Option<&AppleSdkInfo> {
         self.target_distribution.apple_sdk_info()
     }

--- a/pyoxidizer/src/py_packaging/standalone_distribution.rs
+++ b/pyoxidizer/src/py_packaging/standalone_distribution.rs
@@ -1247,6 +1247,7 @@ impl PythonDistribution for StandaloneDistribution {
         libpython_link_mode: BinaryLibpythonLinkMode,
         policy: &PythonPackagingPolicy,
         config: &PyembedPythonInterpreterConfig,
+        runtime_path: Option<String>,
         host_distribution: Option<Arc<dyn PythonDistribution>>,
     ) -> Result<Box<dyn PythonBinaryBuilder>> {
         // TODO can we avoid these clones?
@@ -1263,6 +1264,7 @@ impl PythonDistribution for StandaloneDistribution {
             libpython_link_mode,
             policy.clone(),
             config.clone(),
+            runtime_path,
         )?;
 
         Ok(builder as Box<dyn PythonBinaryBuilder>)

--- a/pyoxidizer/src/templates/new-pyoxidizer.bzl.hbs
+++ b/pyoxidizer/src/templates/new-pyoxidizer.bzl.hbs
@@ -210,6 +210,13 @@ def make_exe():
 
         # If no argument passed, the default `PythonInterpreterConfig` is used.
         config=python_config,
+
+        # If no argument passed, an appropriate Rust project will be auto-generated.
+        {{#if rust_init}}
+        runtime="."
+        {{else}}
+        runtime=None
+        {{/if}}
     )
 
     # Install tcl/tk support files to a specified directory so the `tkinter` Python


### PR DESCRIPTION
Allow the use of pyoxidizer's build system in a project created via `init-rust-project`.

This adds a `runtime` option to `PythonDistribution.to_python_executable()` that specifies the path of the Rust project, and defines it during `init-rust-project`

With this, applications that are happy to continue utilizing pyoxidizer's python resource discovery system can continue doing so while still allowing custom Rust code to be included in the final executable.

Closes #335