### PR TITLE
Only export symbols on Linux GNU builds

### DIFF
--- a/pyoxidizer/src/templates/new-build.rs.hbs
+++ b/pyoxidizer/src/templates/new-build.rs.hbs
@@ -121,15 +121,16 @@ fn main() {
     }
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not defined");
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV not defined");
 
     // Export symbols from built binaries. This is needed to ensure libpython's
     // symbols are exported. Without those symbols being exported, loaded extension
     // modules won't find the libpython symbols and won't be able to run.
-    match target_os.as_str() {
-        "linux" => {
+    match (target_os.as_str(), target_env.as_str()) {
+        ("linux", "gnu") => {
             println!("cargo:rustc-link-arg=-Wl,-export-dynamic");
         }
-        "macos" => {
+        ("macos", _) => {
             println!("cargo:rustc-link-arg=-rdynamic");
         }
         _ => {}


### PR DESCRIPTION
This fixes https://github.com/indygreg/PyOxidizer/issues/673.

I also ran into this issue and narrowed it down to this commit: https://github.com/indygreg/PyOxidizer/commit/1ad7fbcf812c230a092389d639dd8ba24d8b7b57

Unfortunately I have no idea why precisely this change breaks musl builds, but reverting these changes somehow makes them work again. Since loading extensions isn't possible on musl builds anyway, I restricted the change in the original commit further to only GNU builds.

