### PR TITLE
Fix link in the documentation

### DIFF
--- a/pyoxidizer/docs/pyoxidizer_packaging_python_distributions.rst
+++ b/pyoxidizer/docs/pyoxidizer_packaging_python_distributions.rst
@@ -178,7 +178,7 @@ Known Issues with Distributions
 
 There are various known issues with various distributions. The
 python-build-standalone project documentation at
-https://python-build-standalone.readthedocs.io/en/latest/ attempts to capture
+https://gregoryszorc.com/docs/python-build-standalone/main/ attempts to capture
 many of them.
 
 PyOxidizer contains workaround for many of the limitations. For example,


### PR DESCRIPTION
The docs of python-build-standalone have been moved so that the link https://python-build-standalone.readthedocs.io/en/latest/ leads to 404.